### PR TITLE
Add pastel-themed navigation and section pages

### DIFF
--- a/education.html
+++ b/education.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Your Name - Portfolio</title>
+  <title>Education - Your Name</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -14,11 +14,11 @@
     <a href="research.html">Research</a>
   </nav>
   <div class="container">
-    <h1>Your Name</h1>
-    <div class="subtitle">PhD Student, Music Technology<br>
-      <a href="mailto:your@email.com">your@email.com</a> | GitHub: <a href="https://github.com/yourusername">yourusername</a>
-    </div>
-    <p>Welcome to my professional portfolio. Use the tabs above to learn more about my background, experience, and research.</p>
+    <h1>Education</h1>
+    <ul>
+      <li class="item"><strong>Seoul National University</strong> – PhD in Music Education, 2024–Present</li>
+      <li class="item"><strong>KAIST</strong> – BS in Computer Science, 2020–2024</li>
+    </ul>
   </div>
 </body>
 </html>

--- a/experience.html
+++ b/experience.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Your Name - Portfolio</title>
+  <title>Experience - Your Name</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -14,11 +14,11 @@
     <a href="research.html">Research</a>
   </nav>
   <div class="container">
-    <h1>Your Name</h1>
-    <div class="subtitle">PhD Student, Music Technology<br>
-      <a href="mailto:your@email.com">your@email.com</a> | GitHub: <a href="https://github.com/yourusername">yourusername</a>
-    </div>
-    <p>Welcome to my professional portfolio. Use the tabs above to learn more about my background, experience, and research.</p>
+    <h1>Experience</h1>
+    <ul>
+      <li class="item"><strong>Music Technology Lab, Seoul National University</strong> – Research Assistant, 2024–Present</li>
+      <li class="item"><strong>AI Startup</strong> – Software Engineering Intern, Summer 2023</li>
+    </ul>
   </div>
 </body>
 </html>

--- a/research.html
+++ b/research.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Research - Your Name</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="education.html">Education</a>
+    <a href="experience.html">Experience</a>
+    <a href="research.html">Research</a>
+  </nav>
+  <div class="container">
+    <h1>Research</h1>
+    <ul>
+      <li class="item"><strong>Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</strong><br><span>Jiyoon Kim, et al., ISMIR 2024</span></li>
+      <li class="item"><strong>Computational Analysis of Expressive Timing in Korean Traditional Jangdan</strong><br><span>Jiyoon Kim, et al., ICMC 2023</span></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+body { font-family: 'Segoe UI', Arial, sans-serif; background: #f5f7fa; margin: 0; color: #222; }
+nav { background: #dde7f5; padding: 12px 24px; display: flex; gap: 20px; border-bottom: 1px solid #cdd6e6; }
+nav a { text-decoration: none; color: #336699; font-weight: 600; }
+nav a:hover { color: #1d4666; }
+.container { max-width: 780px; margin: 40px auto; background: #fff; border-radius: 14px; box-shadow: 0 2px 12px rgba(0,0,0,0.06); padding: 40px 32px 32px 32px; }
+h1 { margin-top: 0; font-size: 2.5rem; font-weight: 700; letter-spacing: -1px; }
+h2 { border-bottom: 1px solid #eaeaea; padding-bottom: 6px; margin-top: 32px; color: #5b7dbd; }
+ul { padding-left: 18px; }
+.subtitle { color: #666; font-size: 1.1em; margin-bottom: 28px; }
+.item { margin-bottom: 18px; }
+@media (max-width: 600px) {
+  .container { padding: 16px 4vw; }
+  h1 { font-size: 2rem; }
+}


### PR DESCRIPTION
## Summary
- Introduce shared pastel-styled navigation bar
- Add dedicated Education, Experience, and Research pages with placeholder content
- Apply central stylesheet for consistent professional pastel design

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a029821e88832e92e95cca38d3666e