### PR TITLE
Add bilingual sidebar layout with language toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,23 +2,214 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Your Name - Portfolio</title>
+  <title>Han Danbinaerin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="education.html">Education</a>
-    <a href="experience.html">Experience</a>
-    <a href="research.html">Research</a>
-  </nav>
-  <div class="container">
-    <h1>Your Name</h1>
-    <div class="subtitle">PhD Student, Music Technology<br>
-      <a href="mailto:your@email.com">your@email.com</a> | GitHub: <a href="https://github.com/yourusername">yourusername</a>
-    </div>
-    <p>Welcome to my professional portfolio. Use the tabs above to learn more about my background, experience, and research.</p>
+<body class="lang-en">
+  <div class="lang-switch">
+    <button id="switch-ko">한국어</button>
+    <button id="switch-en">English</button>
   </div>
+  <div class="layout">
+    <nav class="sidebar">
+      <a href="#cover"><span class="lang-en">Cover</span><span class="lang-ko">표지</span></a>
+      <a href="#contact"><span class="lang-en">Contact</span><span class="lang-ko">연락처</span></a>
+      <a href="#news"><span class="lang-en">News</span><span class="lang-ko">소식</span></a>
+      <a href="#education"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
+      <a href="#publications"><span class="lang-en">Publications</span><span class="lang-ko">논문</span></a>
+      <a href="#prize"><span class="lang-en">Prize</span><span class="lang-ko">수상</span></a>
+      <a href="#talks"><span class="lang-en">Talks</span><span class="lang-ko">발표</span></a>
+      <a href="#honors"><span class="lang-en">Honors & Scholarship</span><span class="lang-ko">장학 및 포상</span></a>
+      <a href="#projects"><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></a>
+      <a href="#support"><span class="lang-en">Support</span><span class="lang-ko">지원</span></a>
+    </nav>
+    <main class="content">
+      <section id="cover">
+        <div class="lang-en">
+          <h1>Han Danbinaerin | Danbinaerin Han</h1>
+          <p><strong>Email:</strong> naerin71@kaist.ac.kr</p>
+          <p>Korean Traditional Music, Music Information Retrieval, Computational Musicology, Haegeum Player</p>
+          <p>I'm a Ph.D Student at Music and Audio Computing Lab, advised by Prof. Juhan Nam.<br>
+          I am exploring 'What Korean music is' using MIR (Music Information Retrieval) techniques.</p>
+        </div>
+        <div class="lang-ko">
+          <h1>한단비내린 | Danbinaerin Han</h1>
+          <p><strong>이메일:</strong> naerin71@kaist.ac.kr</p>
+          <p>한국 전통음악, 음악정보검색, 계산음악학, 해금 연주자</p>
+          <p>저는 Prof. Juhan Nam 교수님이 지도하시는 Music and Audio Computing Lab의 박사과정 학생입니다.<br>
+          MIR(Music Information Retrieval) 기법을 활용하여 '한국 음악이 무엇인가'를 탐구하고 있습니다.</p>
+        </div>
+      </section>
+
+      <section id="contact">
+        <h2><span class="lang-en">📞 Contact</span><span class="lang-ko">📞 연락처</span></h2>
+        <ul>
+          <li><span class="lang-en"><strong>E-mail</strong>: naerin71@kaist.ac.kr | danbinaerin@naver.com</span><span class="lang-ko"><strong>이메일</strong>: naerin71@kaist.ac.kr | danbinaerin@naver.com</span></li>
+          <li><span class="lang-en"><strong>CV</strong>: <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing">Here</a></span><span class="lang-ko"><strong>이력서</strong>: <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing">링크</a></span></li>
+          <li><span class="lang-en"><strong>Github</strong>: <a href="https://github.com/danbinaerinHan">Here</a></span><span class="lang-ko"><strong>깃허브</strong>: <a href="https://github.com/danbinaerinHan">링크</a></span></li>
+          <li><span class="lang-en"><strong>Google scholar</strong>: <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko">Here</a></span><span class="lang-ko"><strong>구글 스칼라</strong>: <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko">링크</a></span></li>
+          <li><span class="lang-en"><strong>Instagram</strong>: @handanbinaerin</span><span class="lang-ko"><strong>인스타그램</strong>: @handanbinaerin</span></li>
+        </ul>
+      </section>
+
+      <section id="news">
+        <h2><span class="lang-en">🤗 News</span><span class="lang-ko">🤗 소식</span></h2>
+        <ul>
+          <li>
+            <span class="lang-en"><strong>2025.06.05:</strong> Guest Appearance on a Special Radio Program for Gugak Day, Gugak FM <a href="https://www.igbf.kr/gugak_web/?sub_num=760&state=view&idx=265797">Link</a> <a href="https://igbf.kr/gugak_web/?sub_num=764&state=view&idx=265509">Link2</a></span>
+            <span class="lang-ko"><strong>2025.06.05:</strong> 국악의 날 기념 국악 FM 특집 라디오 프로그램 출연 <a href="https://www.igbf.kr/gugak_web/?sub_num=760&state=view&idx=265797">링크</a> <a href="https://igbf.kr/gugak_web/?sub_num=764&state=view&idx=265509">링크2</a></span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>2025.05.31:</strong> Session presentation at the 50th Anniversary Conference of the Society of Korean Music Educators</span>
+            <span class="lang-ko"><strong>2025.05.31:</strong> 한국음악교육학회 50주년 기념 학술대회 세션 발표</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>2025.03.13:</strong> Invited talk at MUSAIC, UC San Diego (Remote)</span>
+            <span class="lang-ko"><strong>2025.03.13:</strong> MUSAIC, UC San Diego(원격) 초청 강연</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>2025.01:</strong> "On the automatic recognition of Jeongganbo music notation: dataset and approach" accepted to <em>ACM Journal on Computing and Cultural Heritage (JOCCH)</em></span>
+            <span class="lang-ko"><strong>2025.01:</strong> "정간보 음악 기보의 자동 인식을 위한 데이터셋과 접근법" 논문이 <em>ACM Journal on Computing and Cultural Heritage (JOCCH)</em>에 게재 승인</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="education">
+        <h2><span class="lang-en">Education</span><span class="lang-ko">학력</span></h2>
+        <ul>
+          <li>
+            <span class="lang-en"><strong>Korea Advanced Institute of Science and Technology</strong> (2024.03~)<br>
+            Ph.D. student in Graduate School of Culture Technology<br>
+            Music and Audio Computing (MAC) Lab | Advisor: Prof. Juhan Nam</span>
+            <span class="lang-ko"><strong>한국과학기술원</strong> (2024.03~)<br>
+            문화기술대학원 박사과정<br>
+            Music and Audio Computing (MAC) Lab | 지도교수: 남주한</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>Sogang University</strong> (2022.03~2024.02)<br>
+            M.S. in Arts and Science (Department of Art and Technology)<br>
+            Music and Art Learning (MALer) Lab | Advisor: Prof. Dasaem Jeong<br>
+            GPA: 4.15 / 4.3</span>
+            <span class="lang-ko"><strong>서강대학교</strong> (2022.03~2024.02)<br>
+            예술과학 석사 (예술공학부)<br>
+            Music and Art Learning (MALer) Lab | 지도교수: 정다샘<br>
+            GPA: 4.15 / 4.3</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>Seoul National University</strong> (2017.03~2021.08)<br>
+            Bachelor's Degree in Traditional Korean Music (Graduated with Highest Honors)<br>
+            Teacher Certification Program in Music Education, College of Education<br>
+            GPA: 4.08 / 4.3</span>
+            <span class="lang-ko"><strong>서울대학교</strong> (2017.03~2021.08)<br>
+            국악과 학사 (최우등 졸업)<br>
+            사범대학 음악교육 교원자격 프로그램<br>
+            GPA: 4.08 / 4.3</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>National Gugak Middle & High School</strong> (2011.03~2017.02)<br>
+            Graduated with Highest Honors, Outstanding Major Award</span>
+            <span class="lang-ko"><strong>국립국악중·고등학교</strong> (2011.03~2017.02)<br>
+            최우등 졸업, 전공 최우수상</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="publications">
+        <h2><span class="lang-en">Publications</span><span class="lang-ko">논문</span></h2>
+        <ul>
+          <li>
+            <span class="lang-en">Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding” in Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024 <strong>Best Paper Award</strong></span>
+            <span class="lang-ko">Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding”, 제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024 <strong>최우수 논문상</strong></span>
+          </li>
+          <li>
+            <span class="lang-en">Danbinaerin Han, “Inferring the Transformation of Korean Early Music using Deep Neural Network”, Sogang University, Master Thesis, 2024</span>
+            <span class="lang-ko">Danbinaerin Han, “심층 신경망을 이용한 한국 초기 음악의 변천 추론”, 서강대학교 석사학위 논문, 2024</span>
+          </li>
+          <li>
+            <span class="lang-en">Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, in Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</span>
+            <span class="lang-ko">Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, 제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023</span>
+          </li>
+          <li>
+            <span class="lang-en">Danbinaerin Han, Daewoong Kim, Dasaem Jeong, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, in Proc. of 10th Digital Library for Music(DLfM), 2023</span>
+            <span class="lang-ko">Danbinaerin Han, Daewoong Kim, Dasaem Jeong, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, 제10회 음악 디지털 라이브러리 학회(DLfM) 논문집, 2023</span>
+          </li>
+          <li>
+            <span class="lang-en">Hannah Park, Danbinaerin Han, Chaeryung Oh, Dasaem Jeong, “Fantastic AI Sinawi: Composing Korean Traditional Music Using Deep Neural Networks”, Journal of Digital Contents Society, 2023</span>
+            <span class="lang-ko">Hannah Park, Danbinaerin Han, Chaeryung Oh, Dasaem Jeong, “Fantastic AI Sinawi: 딥러닝을 활용한 한국 전통음악 작곡”, 디지털콘텐츠학회지, 2023</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="prize">
+        <h2><span class="lang-en">Prize</span><span class="lang-ko">수상</span></h2>
+        <ul>
+          <li><span class="lang-en">ISMIR 2024 Best Paper Award (2024)</span><span class="lang-ko">ISMIR 2024 최우수 논문상 (2024)</span></li>
+          <li><span class="lang-en">The Outstanding Paper Award for Graduate Students from Sogang University (2024)</span><span class="lang-ko">서강대학교 대학원 우수논문상 (2024)</span></li>
+          <li><span class="lang-en">1st Metaverse Planning Contest Prize, an encouragement award (2023)</span><span class="lang-ko">1회 메타버스 기획 공모전 장려상 (2023)</span></li>
+          <li><span class="lang-en">2022 ARKO Artist, Producer, Engineer(APE) Camp Winner (2022)</span><span class="lang-ko">2022 ARKO 아티스트, 프로듀서, 엔지니어(APE) 캠프 우승 (2022)</span></li>
+          <li><span class="lang-en">『Haegeum FUN project』1st Prize, Team Leader, Compose & arranger (2021)</span><span class="lang-ko">『해금 FUN 프로젝트』 1위, 팀장, 작곡 및 편곡 (2021)</span></li>
+          <li><span class="lang-en">21st Century Korean Music Project, Yeoriji, ‘A letter from left hand’ (2021)</span><span class="lang-ko">21세기 한국음악 프로젝트, 여리지, ‘왼손의 편지’ (2021)</span></li>
+          <li><span class="lang-en">The 20th Incheon Gugak Grand Festival, 1st Prize (2020)</span><span class="lang-ko">제20회 인천국악대축제 1등 (2020)</span></li>
+          <li><span class="lang-en">The 35th, 36th Dong-A Korean Traditional music Competition, 3rd Prize (2019, 2020)</span><span class="lang-ko">제35·36회 동아국악콩쿠르 3등 (2019, 2020)</span></li>
+          <li><span class="lang-en">The 4th Youngsan Gugak Contest, 1st Prize (2020)</span><span class="lang-ko">제4회 영산국악콩쿠르 1등 (2020)</span></li>
+        </ul>
+      </section>
+
+      <section id="talks">
+        <h2><span class="lang-en">Talks</span><span class="lang-ko">발표</span></h2>
+        <ul>
+          <li><span class="lang-en"><strong>Session Speaker</strong>, May 2025<br>The 50th Anniversary Conference of the Society for Korean Music Educators</span><span class="lang-ko"><strong>세션 발표</strong>, 2025년 5월<br>한국음악교육학회 50주년 기념 학술대회</span></li>
+          <li><span class="lang-en"><strong>Invited Talk (remote)</strong>, March 2025<br>MUSAIC, UC San Diego</span><span class="lang-ko"><strong>초청 강연(비대면)</strong>, 2025년 3월<br>MUSAIC, UC 샌디에이고</span></li>
+          <li><span class="lang-en"><strong>Invited Talk (remote)</strong>, March 2024<br>"Computational Auditory Perception" group at the Max Planck Institute for Empirical Aesthetics in Frankfurt</span><span class="lang-ko"><strong>초청 강연(비대면)</strong>, 2024년 3월<br>막스플랑크 예술인지 연구소 "Computational Auditory Perception" 그룹</span></li>
+          <li><span class="lang-en"><strong>Oral Presentation</strong>, July 2023<br>Music & Audio Workshop in Seoul National University</span><span class="lang-ko"><strong>구두 발표</strong>, 2023년 7월<br>서울대학교 Music & Audio Workshop</span></li>
+          <li><span class="lang-en"><strong>Invited Talk</strong>, June 2022<br>International Music Workshop concert (IMWC), College of Music in Seoul National University</span><span class="lang-ko"><strong>초청 강연</strong>, 2022년 6월<br>서울대학교 음악대학 International Music Workshop Concert(IMWC)</span></li>
+        </ul>
+      </section>
+
+      <section id="honors">
+        <h2><span class="lang-en">Honors & Scholarship</span><span class="lang-ko">장학 및 포상</span></h2>
+        <ul>
+          <li>
+            <span class="lang-en"><strong>National Gugak Middle & High School</strong><br>Valedictorian; Principal’s Award<br>Pernod Ricard Korean Traditional Music Scholarship — approx. USD 8,600</span>
+            <span class="lang-ko"><strong>국립국악중·고등학교</strong><br>수석 졸업; 교장상<br>페르노리카르 한국전통음악 장학금 — 약 미화 8,600달러</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>Seoul National University</strong><br>Valedictorian; Graduated 1st in major<br>Full Tuition Waiver (2017 – 2019) — approx. USD 2,800 each year<br>Academic Merit Scholarship (Seoul National University) (2020) — approx. USD 840</span>
+            <span class="lang-ko"><strong>서울대학교</strong><br>수석 졸업; 전공 1위<br>등록금 전액 면제 (2017–2019) — 매년 약 미화 2,800달러<br>학업 우수 장학금 (2020) — 약 미화 840달러</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>Sogang University</strong><br>Graduate Student Excellence Scholarship (2022 - 2023) — approx. USD 10,000</span>
+            <span class="lang-ko"><strong>서강대학교</strong><br>대학원생 우수 장학금 (2022 - 2023) — 약 미화 10,000달러</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="projects">
+        <h2><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></h2>
+        <ul>
+          <li><span class="lang-en">Project | Restoration Korean Old Music using AI, collaboration with National Gugak Center (2024)</span><span class="lang-ko">프로젝트 | 국립국악원과 협업, AI를 활용한 한국 고음악 복원 (2024)</span></li>
+          <li><span class="lang-en">Exhibition | 『FLOW』 Producer, Sound designer (2023)</span><span class="lang-ko">전시 | 『FLOW』 프로듀서, 사운드 디자이너 (2023)</span></li>
+          <li><span class="lang-en">Performance | 『Fantastic AI Sinawi』 in Music Program of the 23rd International Society for Music Information Retrieval Conference (ISMIR) (2022)</span><span class="lang-ko">공연 | 제23회 국제 음악정보검색학회(ISMIR) 음악 프로그램 『Fantastic AI Sinawi』 (2022)</span></li>
+          <li><span class="lang-en">Virtual production | 『Not at home』 Sound Designer (2022)</span><span class="lang-ko">버추얼 프로덕션 | 『Not at home』 사운드 디자이너 (2022)</span></li>
+          <li><span class="lang-en">Art Film | 『To my mojave』 Sound, Performance (2021)</span><span class="lang-ko">아트 필름 | 『To my mojave』 사운드, 퍼포먼스 (2021)</span></li>
+          <li><span class="lang-en">Performance | 『Chosunilbo Debut Concerts』 (2021)</span><span class="lang-ko">공연 | 『조선일보 데뷔 콘서트』 (2021)</span></li>
+          <li><span class="lang-en">Performance | SNU Orient Express EXM (2021)</span><span class="lang-ko">공연 | 서울대 오리엔트 익스프레스 EXM (2021)</span></li>
+          <li><span class="lang-en">Performance | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span><span class="lang-ko">공연 | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span></li>
+          <li><span class="lang-en">Performance | Poongryu-jeon 『Empoong-nongwol』 (2021)</span><span class="lang-ko">공연 | 풍류전 『Empoong-nongwol』 (2021)</span></li>
+        </ul>
+      </section>
+
+      <section id="support">
+        <h2><span class="lang-en">Support program</span><span class="lang-ko">지원 프로그램</span></h2>
+        <ul>
+          <li><span class="lang-en">ARKO Travel for Research Abroad, Canada, Montreal (2023)</span><span class="lang-ko">ARKO 해외연구여행 지원, 캐나다 몬트리올 (2023)</span></li>
+          <li><span class="lang-en">ARKO International Art Fund Project, Korean x Canada research project (2023)</span><span class="lang-ko">ARKO 국제예술기금 프로젝트, 한국-캐나다 연구 프로젝트 (2023)</span></li>
+        </ul>
+      </section>
+
+    </main>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+document.getElementById('switch-en').addEventListener('click', function() {
+  document.body.classList.remove('lang-ko');
+  document.body.classList.add('lang-en');
+});
+
+document.getElementById('switch-ko').addEventListener('click', function() {
+  document.body.classList.remove('lang-en');
+  document.body.classList.add('lang-ko');
+});

--- a/style.css
+++ b/style.css
@@ -1,14 +1,20 @@
 body { font-family: 'Segoe UI', Arial, sans-serif; background: #f5f7fa; margin: 0; color: #222; }
-nav { background: #dde7f5; padding: 12px 24px; display: flex; gap: 20px; border-bottom: 1px solid #cdd6e6; }
-nav a { text-decoration: none; color: #336699; font-weight: 600; }
-nav a:hover { color: #1d4666; }
-.container { max-width: 780px; margin: 40px auto; background: #fff; border-radius: 14px; box-shadow: 0 2px 12px rgba(0,0,0,0.06); padding: 40px 32px 32px 32px; }
-h1 { margin-top: 0; font-size: 2.5rem; font-weight: 700; letter-spacing: -1px; }
-h2 { border-bottom: 1px solid #eaeaea; padding-bottom: 6px; margin-top: 32px; color: #5b7dbd; }
-ul { padding-left: 18px; }
-.subtitle { color: #666; font-size: 1.1em; margin-bottom: 28px; }
-.item { margin-bottom: 18px; }
-@media (max-width: 600px) {
-  .container { padding: 16px 4vw; }
-  h1 { font-size: 2rem; }
+.lang-switch { position: fixed; top: 10px; right: 20px; z-index: 1000; }
+.lang-switch button { margin-left: 8px; padding: 6px 12px; border: 1px solid #336699; background: #fff; color: #336699; cursor: pointer; border-radius: 4px; }
+.lang-switch button:hover { background: #336699; color: #fff; }
+.layout { display: flex; }
+.sidebar { width: 220px; background: #dde7f5; height: 100vh; position: fixed; top: 0; left: 0; padding-top: 60px; display: flex; flex-direction: column; }
+.sidebar a { padding: 12px 20px; color: #336699; text-decoration: none; font-weight: 600; }
+.sidebar a:hover { background: #cdd6e6; }
+.content { margin-left: 220px; padding: 40px; max-width: 900px; }
+.section { margin-bottom: 40px; }
+h1 { margin-top: 0; font-size: 2.2rem; font-weight: 700; }
+h2 { border-bottom: 1px solid #eaeaea; padding-bottom: 6px; margin-top: 40px; color: #5b7dbd; }
+ul { padding-left: 20px; }
+.lang-ko { display: none; }
+body.lang-ko .lang-ko { display: initial; }
+body.lang-ko .lang-en { display: none; }
+@media (max-width: 700px) {
+  .sidebar { position: static; width: 100%; height: auto; flex-direction: row; overflow-x: auto; }
+  .content { margin-left: 0; padding: 20px; }
 }


### PR DESCRIPTION
## Summary
- Add fixed sidebar navigation and top language switch for Korean/English display
- Provide bilingual sections with updated contact, news, education, publications and more
- Include styling and script for responsive layout and language toggling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02e245b28832e9fd93bcef712ec5b