### PR TITLE
Add bilingual layout and cute professional styling

### DIFF
--- a/education.html
+++ b/education.html
@@ -2,23 +2,40 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Education - Your Name</title>
+  <title>Education - Danbinaerin Han</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="education.html">Education</a>
-    <a href="experience.html">Experience</a>
-    <a href="research.html">Research</a>
-  </nav>
-  <div class="container">
-    <h1>Education</h1>
-    <ul>
-      <li class="item"><strong>Seoul National University</strong> – PhD in Music Education, 2024–Present</li>
-      <li class="item"><strong>KAIST</strong> – BS in Computer Science, 2020–2024</li>
-    </ul>
+<body class="lang-en">
+  <div class="lang-switch">
+    <button id="switch-ko">한국어</button>
+    <button id="switch-en">English</button>
   </div>
+  <div class="layout">
+    <nav class="sidebar">
+      <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
+      <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
+      <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
+      <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+    </nav>
+    <main class="content">
+      <h1><span class="lang-en">Education</span><span class="lang-ko">학력</span></h1>
+      <ul>
+        <li>
+          <span class="lang-en"><strong>Seoul National University</strong> – PhD in Music Education, 2024–Present</span>
+          <span class="lang-ko"><strong>서울대학교</strong> – 음악교육 박사과정, 2024–현재</span>
+        </li>
+        <li>
+          <span class="lang-en"><strong>KAIST</strong> – BS in Computer Science, 2020–2024</span>
+          <span class="lang-ko"><strong>KAIST</strong> – 컴퓨터공학 학사, 2020–2024</span>
+        </li>
+      </ul>
+    </main>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>
+

--- a/experience.html
+++ b/experience.html
@@ -2,23 +2,40 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Experience - Your Name</title>
+  <title>Experience - Danbinaerin Han</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="education.html">Education</a>
-    <a href="experience.html">Experience</a>
-    <a href="research.html">Research</a>
-  </nav>
-  <div class="container">
-    <h1>Experience</h1>
-    <ul>
-      <li class="item"><strong>Music Technology Lab, Seoul National University</strong> – Research Assistant, 2024–Present</li>
-      <li class="item"><strong>AI Startup</strong> – Software Engineering Intern, Summer 2023</li>
-    </ul>
+<body class="lang-en">
+  <div class="lang-switch">
+    <button id="switch-ko">한국어</button>
+    <button id="switch-en">English</button>
   </div>
+  <div class="layout">
+    <nav class="sidebar">
+      <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
+      <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
+      <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
+      <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+    </nav>
+    <main class="content">
+      <h1><span class="lang-en">Experience</span><span class="lang-ko">경험</span></h1>
+      <ul>
+        <li>
+          <span class="lang-en"><strong>Music Technology Lab, Seoul National University</strong> – Research Assistant, 2024–Present</span>
+          <span class="lang-ko"><strong>서울대학교 음악기술연구실</strong> – 연구조교, 2024–현재</span>
+        </li>
+        <li>
+          <span class="lang-en"><strong>AI Startup</strong> – Software Engineering Intern, Summer 2023</span>
+          <span class="lang-ko"><strong>AI 스타트업</strong> – 소프트웨어 엔지니어 인턴, 2023년 여름</span>
+        </li>
+      </ul>
+    </main>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>Han Danbinaerin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="lang-en">

--- a/research.html
+++ b/research.html
@@ -2,23 +2,40 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Research - Your Name</title>
+  <title>Research - Danbinaerin Han</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="education.html">Education</a>
-    <a href="experience.html">Experience</a>
-    <a href="research.html">Research</a>
-  </nav>
-  <div class="container">
-    <h1>Research</h1>
-    <ul>
-      <li class="item"><strong>Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</strong><br><span>Jiyoon Kim, et al., ISMIR 2024</span></li>
-      <li class="item"><strong>Computational Analysis of Expressive Timing in Korean Traditional Jangdan</strong><br><span>Jiyoon Kim, et al., ICMC 2023</span></li>
-    </ul>
+<body class="lang-en">
+  <div class="lang-switch">
+    <button id="switch-ko">한국어</button>
+    <button id="switch-en">English</button>
   </div>
+  <div class="layout">
+    <nav class="sidebar">
+      <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
+      <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
+      <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
+      <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+    </nav>
+    <main class="content">
+      <h1><span class="lang-en">Research</span><span class="lang-ko">연구</span></h1>
+      <ul>
+        <li>
+          <span class="lang-en"><strong>Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</strong><br>Jiyoon Kim, et al., ISMIR 2024</span>
+          <span class="lang-ko"><strong>Six Dragons Fly Again: Transformers와 새로운 인코딩으로 15세기 한국 궁중음악 복원</strong><br>김지윤 외, ISMIR 2024</span>
+        </li>
+        <li>
+          <span class="lang-en"><strong>Computational Analysis of Expressive Timing in Korean Traditional Jangdan</strong><br>Jiyoon Kim, et al., ICMC 2023</span>
+          <span class="lang-ko"><strong>한국 전통 장단의 표현적 타이밍에 대한 계산적 분석</strong><br>김지윤 외, ICMC 2023</span>
+        </li>
+      </ul>
+    </main>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>
+

--- a/style.css
+++ b/style.css
@@ -1,20 +1,98 @@
-body { font-family: 'Segoe UI', Arial, sans-serif; background: #f5f7fa; margin: 0; color: #222; }
-.lang-switch { position: fixed; top: 10px; right: 20px; z-index: 1000; }
-.lang-switch button { margin-left: 8px; padding: 6px 12px; border: 1px solid #336699; background: #fff; color: #336699; cursor: pointer; border-radius: 4px; }
-.lang-switch button:hover { background: #336699; color: #fff; }
+body {
+  font-family: 'Poppins', 'Noto Sans KR', sans-serif;
+  background: #fcfbff;
+  margin: 0;
+  color: #333;
+}
+
+.lang-switch {
+  position: fixed;
+  top: 10px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.lang-switch button {
+  margin-left: 8px;
+  padding: 6px 12px;
+  border: 2px solid #a5b4fc;
+  background: #fff;
+  color: #606fc7;
+  cursor: pointer;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.lang-switch button:hover {
+  background: #a5b4fc;
+  color: #fff;
+}
+
 .layout { display: flex; }
-.sidebar { width: 220px; background: #dde7f5; height: 100vh; position: fixed; top: 0; left: 0; padding-top: 60px; display: flex; flex-direction: column; }
-.sidebar a { padding: 12px 20px; color: #336699; text-decoration: none; font-weight: 600; }
-.sidebar a:hover { background: #cdd6e6; }
-.content { margin-left: 220px; padding: 40px; max-width: 900px; }
+
+.sidebar {
+  width: 240px;
+  background: #eef1ff;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding-top: 60px;
+  display: flex;
+  flex-direction: column;
+  border-right: 2px solid #e0e4ff;
+}
+
+.sidebar a {
+  padding: 12px 20px;
+  color: #606fc7;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 4px;
+}
+
+.sidebar a:hover {
+  background: #dce1ff;
+  color: #3743a3;
+}
+
+.content {
+  margin-left: 240px;
+  padding: 40px;
+  max-width: 900px;
+}
+
 .section { margin-bottom: 40px; }
-h1 { margin-top: 0; font-size: 2.2rem; font-weight: 700; }
-h2 { border-bottom: 1px solid #eaeaea; padding-bottom: 6px; margin-top: 40px; color: #5b7dbd; }
+
+h1 {
+  margin-top: 0;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #3743a3;
+}
+
+h2 {
+  border-bottom: 1px solid #eaeaea;
+  padding-bottom: 6px;
+  margin-top: 40px;
+  color: #4f5fb3;
+}
+
 ul { padding-left: 20px; }
+
 .lang-ko { display: none; }
 body.lang-ko .lang-ko { display: initial; }
 body.lang-ko .lang-en { display: none; }
+
 @media (max-width: 700px) {
-  .sidebar { position: static; width: 100%; height: auto; flex-direction: row; overflow-x: auto; }
+  .sidebar {
+    position: static;
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    overflow-x: auto;
+    border-right: none;
+    border-bottom: 2px solid #e0e4ff;
+  }
   .content { margin-left: 0; padding: 20px; }
 }


### PR DESCRIPTION
## Summary
- Move navigation to a fixed left sidebar with main content on the right across pages.
- Add top-right language switch that toggles Korean/English content for each page.
- Refresh fonts and colors using Google Fonts for a professional yet playful look.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03074dc74832e96567cf42bafcd1a