### PR TITLE
Remove large profile image from English homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <body>
     <a href="index_ko.html">한국어</a>
     <a href="index.html">English</a>
-        <img src="images/profile.png" alt="Danbinaerin Han">
       <a href="#cover">Cover</a>
       <a href="#contact">Contact</a>
       <a href="#news">News</a>


### PR DESCRIPTION
## Summary
- remove large profile image from English `index.html`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03c0b4330832e910ec8843885bb48