### PR TITLE
Remove contact section and add icon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
   <div class="lang-switch">
@@ -18,7 +19,6 @@
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
       <a href="#cover">Cover</a>
-      <a href="#contact">Contact</a>
       <a href="#news">News</a>
       <a href="#education">Education</a>
       <a href="#publications">Publications</a>
@@ -32,21 +32,17 @@
       <section id="cover">
         <div>
           <h1>Danbinaerin Han</h1>
-          <p><strong>E-mail:</strong> naerin71@kaist.ac.kr</p>
+          <p><strong>E-mail:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
+          <div class="social-icons">
+            <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="CV" target="_blank"><i class="fa-solid fa-file"></i></a>
+            <a href="https://github.com/danbinaerinHan" class="icon" title="GitHub" target="_blank"><i class="fab fa-github"></i></a>
+            <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko" class="icon" title="Google Scholar" target="_blank"><i class="fa-solid fa-graduation-cap"></i></a>
+            <a href="https://instagram.com/handanbinaerin" class="icon" title="Instagram" target="_blank"><i class="fab fa-instagram"></i></a>
+          </div>
           <p>Korean traditional music, music information retrieval, computational musicology, Haegeum player</p>
           <p>I am a PhD student in the Music and Audio Computing Lab under Prof. Juhan Nam.<br>
           I explore "what is Korean music" using MIR techniques.</p>
         </div>
-      </section>
-      <section id="contact">
-        <h2>📞 Contact</h2>
-        <ul>
-          <li><strong>E-mail</strong>: naerin71@kaist.ac.kr | danbinaerin@naver.com</li>
-          <li><strong>CV</strong>: <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing">Here</a></li>
-          <li><strong>Github</strong>: <a href="https://github.com/danbinaerinHan">Here</a></li>
-          <li><strong>Google scholar</strong>: <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko">Here</a></li>
-          <li><strong>Instagram</strong>: @handanbinaerin</li>
-        </ul>
       </section>
       <section id="news">
         <h2>🤗 News</h2>

--- a/index_ko.html
+++ b/index_ko.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
   <div class="lang-switch">
@@ -17,12 +18,11 @@
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
-      <a href="#cover">한단비내린</a>
-      <a href="#contact">연락처</a>
-      <a href="#news">소식</a>
-      <a href="#education">학력</a>
-      <a href="#publications">연구</a>
-      <a href="#prize">수상</a>
+        <a href="#cover">한단비내린</a>
+        <a href="#news">소식</a>
+        <a href="#education">학력</a>
+        <a href="#publications">연구</a>
+        <a href="#prize">수상</a>
       <a href="#talks">발표</a>
       <a href="#honors">장학</a>
       <a href="#projects">프로젝트</a>
@@ -31,25 +31,21 @@
     <main class="content">
       <section id="cover">
         
-        <div>
-          <h1>한 단비내린</h1>
-          <p><strong>안녕하세요, 한단비내린입니다</strong></p>
-          <p>한국 전통음악, 음악정보검색, 전한음악학, 해금 연주자</p>
-          <p>남주한교수님이 지도하시는 Music and Audio Computing Lab(MACLab)의 박사과정 학생입니다.<br>
-          MIR(Music Information Retrieval) 기법을 활용하여 '한국 음악이 무엇인가'를 탐구하고 있습니다.</p>
-        </div>
-      </section>
-
-      <section id="contact">
-        <h2>📞 연락처</h2>
-        <ul>
-          <li><strong>이메일</strong>: naerin71@kaist.ac.kr | danbinaerin@naver.com</li>
-          <li><strong>이력서</strong>: <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing">링크</a></li>
-          <li><strong>깃허브</strong>: <a href="https://github.com/danbinaerinHan">링크</a></li>
-          <li><strong>구글 스칼라</strong>: <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko">링크</a></li>
-          <li><strong>인스타그램</strong>: @handanbinaerin</li>
-        </ul>
-      </section>
+          <div>
+            <h1>한 단비내린</h1>
+            <p><strong>이메일:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
+            <div class="social-icons">
+              <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="이력서" target="_blank"><i class="fa-solid fa-file"></i></a>
+              <a href="https://github.com/danbinaerinHan" class="icon" title="깃허브" target="_blank"><i class="fab fa-github"></i></a>
+              <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko" class="icon" title="구글 스칼라" target="_blank"><i class="fa-solid fa-graduation-cap"></i></a>
+              <a href="https://instagram.com/handanbinaerin" class="icon" title="인스타그램" target="_blank"><i class="fab fa-instagram"></i></a>
+            </div>
+            <p><strong>안녕하세요, 한단비내린입니다</strong></p>
+            <p>한국 전통음악, 음악정보검색, 전한음악학, 해금 연주자</p>
+            <p>남주한교수님이 지도하시는 Music and Audio Computing Lab(MACLab)의 박사과정 학생입니다.<br>
+            MIR(Music Information Retrieval) 기법을 활용하여 '한국 음악이 무엇인가'를 탐구하고 있습니다.</p>
+          </div>
+        </section>
 
       <section id="news">
         <h2>🤗 소식</h2>

--- a/style.css
+++ b/style.css
@@ -103,6 +103,29 @@ h2 {
 
 ul { padding-left: 20px; }
 
+.social-icons {
+  margin: 8px 0 16px;
+}
+
+.social-icons .icon {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  border: 2px solid #606fc7;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  color: #606fc7;
+  text-decoration: none;
+  margin-right: 8px;
+  font-size: 14px;
+}
+
+.social-icons .icon:hover {
+  background: #606fc7;
+  color: #fff;
+}
+
 @media (max-width: 700px) {
   .sidebar {
     position: static;


### PR DESCRIPTION
## Summary
- Drop the Contact section and relocate email to the cover
- Replace text links for CV, GitHub, Google Scholar, and Instagram with circular icon buttons
- Style new social icons for consistent appearance

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a061a49de4832e8c92434f5130db25