### PR TITLE
Replace publications section with research topics

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       <a href="#contact">Contact</a>
       <a href="#news">News</a>
       <a href="#education">Education</a>
-      <a href="#publications">Publications</a>
+      <a href="#research">Research</a>
       <a href="#prize">Prize</a>
       <a href="#talks">Talks</a>
       <a href="#honors">Honors & Scholarship</a>
@@ -66,15 +66,28 @@
           <li><strong>National Gugak Middle & High School</strong> (2011.03~2017.02)<br>Graduated with Highest Honors, Outstanding Major Award</li>
         </ul>
       </section>
-      <section id="publications">
-        <h2>Publications</h2>
-        <ul>
-          <li>Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding” in Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024 <strong>Best Paper Award</strong></li>
-          <li>Danbinaerin Han, “Inferring the Transformation of Korean Early Music using Deep Neural Network”, Sogang University, Master Thesis, 2024</li>
-          <li>Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, in Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</li>
-          <li>Danbinaerin Han, Daewoong Kim, Dasaem Jeong, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, in Proc. of 10th Digital Library for Music(DLfM), 2023</li>
-          <li>Hannah Park, Danbinaerin Han, Chaeryung Oh, Dasaem Jeong, “Fantastic AI Sinawi: Composing Korean Traditional Music Using Deep Neural Networks”, Journal of Digital Contents Society, 2023</li>
-        </ul>
+      <section id="research">
+        <h2>Research</h2>
+        <div class="research-topic">
+          <h3>Analyzing Korean Folk Song</h3>
+          <button class="more-btn" data-target="topic1">More</button>
+          <div id="topic1" class="more-content">
+            <ul>
+              <li>Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, in Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</li>
+            </ul>
+          </div>
+        </div>
+        <div class="research-topic">
+          <h3>Korean Traditional Music Generation</h3>
+          <button class="more-btn" data-target="topic2">More</button>
+          <div id="topic2" class="more-content">
+            <ul>
+              <li>Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding” in Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024 <strong>Best Paper Award</strong></li>
+              <li>Danbinaerin Han, Daewoong Kim, Dasaem Jeong, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, in Proc. of 10th Digital Library for Music(DLfM), 2023</li>
+              <li>Hannah Park, Danbinaerin Han, Chaeryung Oh, Dasaem Jeong, “Fantastic AI Sinawi: Composing Korean Traditional Music Using Deep Neural Networks”, Journal of Digital Contents Society, 2023</li>
+            </ul>
+          </div>
+        </div>
       </section>
       <section id="prize">
         <h2>Prize</h2>

--- a/index_ko.html
+++ b/index_ko.html
@@ -21,7 +21,7 @@
       <a href="#contact">연락처</a>
       <a href="#news">소식</a>
       <a href="#education">학력</a>
-      <a href="#publications">연구</a>
+      <a href="#research">연구</a>
       <a href="#prize">수상</a>
       <a href="#talks">발표</a>
       <a href="#honors">장학</a>
@@ -104,31 +104,29 @@
         </ul>
       </section>
 
-      <section id="publications">
-        <h2>논문</h2>
-        <ul>
-          <li>
-
-            한단비내린, Mark Gotham, 김동민, 박한나, 이시훈, 정다샘, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding”, 제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024 <strong>최우수 논문상</strong>
-          </li>
-          <li>
-            
-            한단비내린, “심층 신경망을 이용한 한국 초기 음악의 변천 추론”, 서강대학교 석사학위 논문, 2024
-          </li>
-          <li>
-
-            한단비내린, Rafael Caro Repetto, 정다샘, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, 제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023
-          </li>
-          <li>
-
-            한단비내린, 김대웅, 정다샘, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, 제10회 음악 디지털 라이브러리 학회(DLfM) 논문집, 2023
-          </li>
-          <li>
-
-            박한나, 한단비내린, 오채령, 정다샘, “Fantastic AI Sinawi: 딥러닝을 활용한 한국 전통음악 작곡”, 디지털콘텐츠학회지, 2023
-          </li>
-        </ul>
-      </section>
+        <section id="research">
+          <h2>연구</h2>
+          <div class="research-topic">
+            <h3>한국 민요 분석</h3>
+            <button class="more-btn" data-target="topic1-ko">더보기</button>
+            <div id="topic1-ko" class="more-content">
+              <ul>
+                <li>한단비내린, Rafael Caro Repetto, 정다샘, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, 제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023</li>
+              </ul>
+            </div>
+          </div>
+          <div class="research-topic">
+            <h3>한국 전통음악 생성</h3>
+            <button class="more-btn" data-target="topic2-ko">더보기</button>
+            <div id="topic2-ko" class="more-content">
+              <ul>
+                <li>한단비내린, Mark Gotham, 김동민, 박한나, 이시훈, 정다샘, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding”, 제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024 <strong>최우수 논문상</strong></li>
+                <li>한단비내린, 김대웅, 정다샘, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, 제10회 음악 디지털 라이브러리 학회(DLfM) 논문집, 2023</li>
+                <li>박한나, 한단비내린, 오채령, 정다샘, “Fantastic AI Sinawi: 딥러닝을 활용한 한국 전통음악 작곡”, 디지털콘텐츠학회지, 2023</li>
+              </ul>
+            </div>
+          </div>
+        </section>
 
       <section id="prize">
         <h2>수상</h2>

--- a/script.js
+++ b/script.js
@@ -34,4 +34,14 @@ document.addEventListener('DOMContentLoaded', function() {
       window.addEventListener('scroll', activateSidebar);
       activateSidebar();
     }
+
+  const moreButtons = document.querySelectorAll('.more-btn');
+  moreButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = document.getElementById(btn.dataset.target);
+      if (target) {
+        target.classList.toggle('open');
+      }
+    });
+  });
 });

--- a/style.css
+++ b/style.css
@@ -103,6 +103,33 @@ h2 {
 
 ul { padding-left: 20px; }
 
+.research-topic { margin-bottom: 20px; }
+
+.more-btn {
+  margin-top: 8px;
+  padding: 6px 12px;
+  border: 2px solid #a5b4fc;
+  background: #fff;
+  color: #606fc7;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.more-btn:hover {
+  background: #a5b4fc;
+  color: #fff;
+}
+
+.more-content {
+  display: none;
+  margin-top: 10px;
+}
+
+.more-content.open {
+  display: block;
+}
+
 @media (max-width: 700px) {
   .sidebar {
     position: static;


### PR DESCRIPTION
## Summary
- Rename navigation link and section from Publications to Research.
- Group research into "Analyzing Korean Folk Song" and "Korean Traditional Music Generation" with expandable 'More' buttons.
- Add styling and JavaScript to support collapsible research details.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0630fa1d4832e9bb31091bf36e085