### PR TITLE
Add expandable research publications with improved styling

### DIFF
--- a/research.html
+++ b/research.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body class="lang-en">
   <div class="lang-switch">
@@ -24,16 +25,23 @@
     </nav>
     <main class="content">
       <h1><span class="lang-en">Research</span><span class="lang-ko">연구</span></h1>
-      <ul>
-        <li>
-          <span class="lang-en"><strong>Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</strong><br>Jiyoon Kim, et al., ISMIR 2024</span>
-          <span class="lang-ko"><strong>Six Dragons Fly Again: Transformers와 새로운 인코딩으로 15세기 한국 궁중음악 복원</strong><br>김지윤 외, ISMIR 2024</span>
-        </li>
-        <li>
-          <span class="lang-en"><strong>Computational Analysis of Expressive Timing in Korean Traditional Jangdan</strong><br>Jiyoon Kim, et al., ICMC 2023</span>
-          <span class="lang-ko"><strong>한국 전통 장단의 표현적 타이밍에 대한 계산적 분석</strong><br>김지윤 외, ICMC 2023</span>
-        </li>
-      </ul>
+      <button class="more-btn" data-target="pub-list">
+        <span class="lang-en">More</span>
+        <span class="lang-ko">더보기</span>
+        <i class="fa-solid fa-chevron-down"></i>
+      </button>
+      <div id="pub-list" class="more-content">
+        <ul>
+          <li>
+            <span class="lang-en"><strong>Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</strong><br>Jiyoon Kim, et al., ISMIR 2024</span>
+            <span class="lang-ko"><strong>Six Dragons Fly Again: Transformers와 새로운 인코딩으로 15세기 한국 궁중음악 복원</strong><br>김지윤 외, ISMIR 2024</span>
+          </li>
+          <li>
+            <span class="lang-en"><strong>Computational Analysis of Expressive Timing in Korean Traditional Jangdan</strong><br>Jiyoon Kim, et al., ICMC 2023</span>
+            <span class="lang-ko"><strong>한국 전통 장단의 표현적 타이밍에 대한 계산적 분석</strong><br>김지윤 외, ICMC 2023</span>
+          </li>
+        </ul>
+      </div>
     </main>
   </div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const target = document.getElementById(btn.dataset.target);
       if (target) {
         target.classList.toggle('open');
+        btn.classList.toggle('open');
       }
     });
   });

--- a/style.css
+++ b/style.css
@@ -48,17 +48,20 @@ body {
 }
 
 .sidebar .profile {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 20px;
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 20px;
+  border-radius: 50%;
+  overflow: hidden;
 }
 
 .sidebar .profile img {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   object-position: top;
+  transform: scale(1.3);
+  transform-origin: top center;
 }
 
 .sidebar a {
@@ -125,6 +128,42 @@ ul { padding-left: 20px; }
 .social-icons .icon:hover {
   background: #606fc7;
   color: #fff;
+}
+
+.more-content {
+  display: none;
+  margin-top: 8px;
+}
+
+.more-content.open {
+  display: block;
+}
+
+.more-btn {
+  margin-top: 8px;
+  padding: 6px 12px;
+  border: 2px solid #606fc7;
+  background: #fff;
+  color: #606fc7;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.more-btn:hover {
+  background: #606fc7;
+  color: #fff;
+}
+
+.more-btn i {
+  transition: transform 0.3s;
+}
+
+.more-btn.open i {
+  transform: rotate(180deg);
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- Hide research publications until a "More" button is pressed and reveal them with a rotating arrow icon
- Style generic More buttons and zoom the sidebar profile photo for a tighter crop
- Link Font Awesome for icons on the research page

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a065540cb4832ea2e5f09218e30a14