### PR TITLE
style: center section headings and reorder talks

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
       <a href="#news">News</a>
       <a href="#education">Education</a>
       <a href="#research">Research</a>
-      <a href="#prize">Prize</a>
       <a href="#talks">Talks</a>
+      <a href="#prize">Prize</a>
       <a href="#honors">Honors & Scholarship</a>
       <a href="#projects">Projects</a>
       <a href="#support">Support</a>
@@ -85,6 +85,16 @@
           </div>
         </div>
       </section>
+      <section id="talks">
+        <h2>Talks</h2>
+        <ul>
+          <li><strong>Session Speaker</strong>, May 2025<br>The 50th Anniversary Conference of the Society for Korean Music Educators</li>
+          <li><strong>Invited Talk (remote)</strong>, March 2025<br>MUSAIC, UC San Diego</li>
+          <li><strong>Invited Talk (remote)</strong>, March 2024<br>"Computational Auditory Perception" group at the Max Planck Institute for Empirical Aesthetics in Frankfurt</li>
+          <li><strong>Oral Presentation</strong>, July 2023<br>Music & Audio Workshop in Seoul National University</li>
+          <li><strong>Invited Talk</strong>, June 2022<br>International Music Workshop concert (IMWC), College of Music in Seoul National University</li>
+        </ul>
+      </section>
       <section id="prize">
         <h2>Prize</h2>
         <ul>
@@ -97,16 +107,6 @@
           <li>The 20th Incheon Gugak Grand Festival, 1st Prize (2020)</li>
           <li>The 35th, 36th Dong-A Korean Traditional music Competition, 3rd Prize (2019, 2020)</li>
           <li>The 4th Youngsan Gugak Contest, 1st Prize (2020)</li>
-        </ul>
-      </section>
-      <section id="talks">
-        <h2>Talks</h2>
-        <ul>
-          <li><strong>Session Speaker</strong>, May 2025<br>The 50th Anniversary Conference of the Society for Korean Music Educators</li>
-          <li><strong>Invited Talk (remote)</strong>, March 2025<br>MUSAIC, UC San Diego</li>
-          <li><strong>Invited Talk (remote)</strong>, March 2024<br>"Computational Auditory Perception" group at the Max Planck Institute for Empirical Aesthetics in Frankfurt</li>
-          <li><strong>Oral Presentation</strong>, July 2023<br>Music & Audio Workshop in Seoul National University</li>
-          <li><strong>Invited Talk</strong>, June 2022<br>International Music Workshop concert (IMWC), College of Music in Seoul National University</li>
         </ul>
       </section>
       <section id="honors">

--- a/index_ko.html
+++ b/index_ko.html
@@ -22,8 +22,8 @@
         <a href="#news">소식</a>
         <a href="#education">학력</a>
         <a href="#publications">연구</a>
-        <a href="#prize">수상</a>
       <a href="#talks">발표</a>
+        <a href="#prize">수상</a>
       <a href="#honors">장학</a>
       <a href="#projects">프로젝트</a>
       <a href="#support">지원</a>
@@ -124,6 +124,17 @@
           </div>
         </section>
 
+      <section id="talks">
+        <h2>발표</h2>
+        <ul>
+          <li><strong>세션 발표</strong>, 2025년 5월<br>한국음악교육학회 50주년 기념 학술대회</li>
+          <li><strong>초청 강연(비대면)</strong>, 2025년 3월<br>MUSAIC, UC 샌디에이고</li>
+          <li><strong>초청 강연(비대면)</strong>, 2024년 3월<br>막스플랑크 예술인지 연구소 "Computational Auditory Perception" 그룹</li>
+          <li><strong>구두 발표</strong>, 2023년 7월<br>서울대학교 Music & Audio Workshop</li>
+          <li><strong>초청 강연</strong>, 2022년 6월<br>서울대학교 음악대학 International Music Workshop Concert(IMWC)</li>
+        </ul>
+      </section>
+
       <section id="prize">
         <h2>수상</h2>
         <ul>
@@ -136,17 +147,6 @@
           <li>제20회 인천국악대축제 1등 (2020)</li>
           <li>제35·36회 동아국악콩쿠르 3등 (2019, 2020)</li>
           <li>제4회 영산국악콩쿠르 1등 (2020)</li>
-        </ul>
-      </section>
-
-      <section id="talks">
-        <h2>발표</h2>
-        <ul>
-          <li><strong>세션 발표</strong>, 2025년 5월<br>한국음악교육학회 50주년 기념 학술대회</li>
-          <li><strong>초청 강연(비대면)</strong>, 2025년 3월<br>MUSAIC, UC 샌디에이고</li>
-          <li><strong>초청 강연(비대면)</strong>, 2024년 3월<br>막스플랑크 예술인지 연구소 "Computational Auditory Perception" 그룹</li>
-          <li><strong>구두 발표</strong>, 2023년 7월<br>서울대학교 Music & Audio Workshop</li>
-          <li><strong>초청 강연</strong>, 2022년 6월<br>서울대학교 음악대학 International Music Workshop Concert(IMWC)</li>
         </ul>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -41,7 +41,7 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  padding-top: 60px;
+  padding-top: 80px;
   display: flex;
   flex-direction: column;
   border-right: 2px solid #e0e4ff;
@@ -84,7 +84,7 @@ body {
 
 .content {
   margin-left: 240px;
-  padding: 40px;
+  padding: 60px 40px 40px;
   max-width: 900px;
 }
 
@@ -95,13 +95,14 @@ h1 {
   font-size: 2.2rem;
   font-weight: 700;
   color: #3743a3;
+  text-align: center;
 }
 
 h2 {
-  border-bottom: 1px solid #eaeaea;
   padding-bottom: 6px;
   margin-top: 40px;
   color: #4f5fb3;
+  text-align: center;
 }
 
 ul { padding-left: 20px; }


### PR DESCRIPTION
## Summary
- center major headings and drop decorative section lines
- move Talks above Prize in navigation and content
- provide extra breathing room at the top of the page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0677ecf14832e8fff5a4f3ffd751a