### PR TITLE
Align titles left and tweak research layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,15 +33,15 @@
         <div>
           <h1>Danbinaerin Han</h1>
           <p><strong>E-mail:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
+          <p>Korean traditional music, music information retrieval, computational musicology, Haegeum player</p>
+          <p>I am a PhD student in the Music and Audio Computing Lab under Prof. Juhan Nam.<br>
+          I explore "what is Korean music" using MIR techniques.</p>
           <div class="social-icons">
             <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="CV" target="_blank"><i class="fa-solid fa-file"></i></a>
             <a href="https://github.com/danbinaerinHan" class="icon" title="GitHub" target="_blank"><i class="fab fa-github"></i></a>
             <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko" class="icon" title="Google Scholar" target="_blank"><i class="fa-solid fa-graduation-cap"></i></a>
             <a href="https://instagram.com/handanbinaerin" class="icon" title="Instagram" target="_blank"><i class="fab fa-instagram"></i></a>
           </div>
-          <p>Korean traditional music, music information retrieval, computational musicology, Haegeum player</p>
-          <p>I am a PhD student in the Music and Audio Computing Lab under Prof. Juhan Nam.<br>
-          I explore "what is Korean music" using MIR techniques.</p>
         </div>
       </section>
       <section id="news">
@@ -65,8 +65,10 @@
       <section id="research">
         <h2>Research</h2>
         <div class="research-topic">
-          <h3>Analyzing Korean Folk Song</h3>
-          <button class="more-btn" data-target="topic1">More</button>
+          <div class="topic-header">
+            <h3>Analyzing Korean Folk Song</h3>
+            <button class="more-btn" data-target="topic1">More</button>
+          </div>
           <div id="topic1" class="more-content">
             <ul>
               <li>Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, in Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</li>
@@ -74,8 +76,10 @@
           </div>
         </div>
         <div class="research-topic">
-          <h3>Korean Traditional Music Generation</h3>
-          <button class="more-btn" data-target="topic2">More</button>
+          <div class="topic-header">
+            <h3>Korean Traditional Music Generation</h3>
+            <button class="more-btn" data-target="topic2">More</button>
+          </div>
           <div id="topic2" class="more-content">
             <ul>
               <li>Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding” in Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024 <strong>Best Paper Award</strong></li>

--- a/index_ko.html
+++ b/index_ko.html
@@ -34,16 +34,16 @@
           <div>
             <h1>한 단비내린</h1>
             <p><strong>이메일:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
+            <p><strong>안녕하세요, 한단비내린입니다</strong></p>
+            <p>한국 전통음악, 음악정보검색, 전한음악학, 해금 연주자</p>
+            <p>남주한교수님이 지도하시는 Music and Audio Computing Lab(MACLab)의 박사과정 학생입니다.<br>
+            MIR(Music Information Retrieval) 기법을 활용하여 '한국 음악이 무엇인가'를 탐구하고 있습니다.</p>
             <div class="social-icons">
               <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="이력서" target="_blank"><i class="fa-solid fa-file"></i></a>
               <a href="https://github.com/danbinaerinHan" class="icon" title="깃허브" target="_blank"><i class="fab fa-github"></i></a>
               <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko" class="icon" title="구글 스칼라" target="_blank"><i class="fa-solid fa-graduation-cap"></i></a>
               <a href="https://instagram.com/handanbinaerin" class="icon" title="인스타그램" target="_blank"><i class="fab fa-instagram"></i></a>
             </div>
-            <p><strong>안녕하세요, 한단비내린입니다</strong></p>
-            <p>한국 전통음악, 음악정보검색, 전한음악학, 해금 연주자</p>
-            <p>남주한교수님이 지도하시는 Music and Audio Computing Lab(MACLab)의 박사과정 학생입니다.<br>
-            MIR(Music Information Retrieval) 기법을 활용하여 '한국 음악이 무엇인가'를 탐구하고 있습니다.</p>
           </div>
         </section>
 
@@ -103,8 +103,10 @@
         <section id="research">
           <h2>연구</h2>
           <div class="research-topic">
-            <h3>한국 민요 분석</h3>
-            <button class="more-btn" data-target="topic1-ko">더보기</button>
+            <div class="topic-header">
+              <h3>한국 민요 분석</h3>
+              <button class="more-btn" data-target="topic1-ko">더보기</button>
+            </div>
             <div id="topic1-ko" class="more-content">
               <ul>
                 <li>한단비내린, Rafael Caro Repetto, 정다샘, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, 제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023</li>
@@ -112,8 +114,10 @@
             </div>
           </div>
           <div class="research-topic">
-            <h3>한국 전통음악 생성</h3>
-            <button class="more-btn" data-target="topic2-ko">더보기</button>
+            <div class="topic-header">
+              <h3>한국 전통음악 생성</h3>
+              <button class="more-btn" data-target="topic2-ko">더보기</button>
+            </div>
             <div id="topic2-ko" class="more-content">
               <ul>
                 <li>한단비내린, Mark Gotham, 김동민, 박한나, 이시훈, 정다샘, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding”, 제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024 <strong>최우수 논문상</strong></li>

--- a/research.html
+++ b/research.html
@@ -24,12 +24,14 @@
       <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
     </nav>
     <main class="content">
-      <h1><span class="lang-en">Research</span><span class="lang-ko">연구</span></h1>
-      <button class="more-btn" data-target="pub-list">
-        <span class="lang-en">More</span>
-        <span class="lang-ko">더보기</span>
-        <i class="fa-solid fa-chevron-down"></i>
-      </button>
+      <div class="page-header">
+        <h1><span class="lang-en">Research</span><span class="lang-ko">연구</span></h1>
+        <button class="more-btn" data-target="pub-list">
+          <span class="lang-en">More</span>
+          <span class="lang-ko">더보기</span>
+          <i class="fa-solid fa-chevron-down"></i>
+        </button>
+      </div>
       <div id="pub-list" class="more-content">
         <ul>
           <li>

--- a/style.css
+++ b/style.css
@@ -95,18 +95,28 @@ h1 {
   font-size: 2.2rem;
   font-weight: 700;
   color: #3743a3;
-  text-align: center;
+  text-align: left;
 }
 
 h2 {
   padding-bottom: 6px;
   margin-top: 40px;
   color: #4f5fb3;
-  text-align: center;
+  text-align: left;
 }
 
 ul { padding-left: 20px; }
 
+#cover {
+  padding: 40px 0;
+}
+
+.topic-header,
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
 
 .social-icons {
   margin: 8px 0 16px;


### PR DESCRIPTION
## Summary
- Left-align top-level headings and add breathing room around the cover section
- Place research "More" buttons to the right of their topics for both English and Korean pages
- Move social icon set below the introductory tagline on home pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06b04ceb0832eb28a3355b0c20c88