### PR TITLE
feat: isolate projects section

### DIFF
--- a/education.html
+++ b/education.html
@@ -21,6 +21,7 @@
       <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
       <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
       <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+      <a href="project.html" class="project-link"><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></a>
     </nav>
     <main class="content">
       <h1><span class="lang-en">Education</span><span class="lang-ko">학력</span></h1>

--- a/experience.html
+++ b/experience.html
@@ -21,6 +21,7 @@
       <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
       <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
       <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+      <a href="project.html" class="project-link"><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></a>
     </nav>
     <main class="content">
       <h1><span class="lang-en">Experience</span><span class="lang-ko">경험</span></h1>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,7 @@
       <a href="#research">Research</a>
       <a href="#talks">Talks</a>
       <a href="#prize">Prize</a>
-      <a href="#honors">Honors & Scholarship</a>
-      <a href="#projects">Projects</a>
-      <a href="#support">Support</a>
+      <a href="project.html" class="project-link">Projects</a>
     </nav>
     <main class="content">
       <section id="cover">
@@ -111,35 +109,6 @@
           <li>The 20th Incheon Gugak Grand Festival, 1st Prize (2020)</li>
           <li>The 35th, 36th Dong-A Korean Traditional music Competition, 3rd Prize (2019, 2020)</li>
           <li>The 4th Youngsan Gugak Contest, 1st Prize (2020)</li>
-        </ul>
-      </section>
-      <section id="honors">
-        <h2>Honors & Scholarship</h2>
-        <ul>
-          <li><strong>National Gugak Middle & High School</strong><br>Valedictorian; Principal’s Award<br>Pernod Ricard Korean Traditional Music Scholarship — approx. USD 8,600</li>
-          <li><strong>Seoul National University</strong><br>Valedictorian; Graduated 1st in major<br>Full Tuition Waiver (2017 – 2019) — approx. USD 2,800 each year<br>Academic Merit Scholarship (Seoul National University) (2020) — approx. USD 840</li>
-          <li><strong>Sogang University</strong><br>Graduate Student Excellence Scholarship (2022 - 2023) — approx. USD 10,000</li>
-        </ul>
-      </section>
-      <section id="projects">
-        <h2>Projects</h2>
-        <ul>
-          <li>Project | Restoration Korean Old Music using AI, collaboration with National Gugak Center (2024)</li>
-          <li>Exhibition | 『FLOW』 Producer, Sound designer (2023)</li>
-          <li>Performance | 『Fantastic AI Sinawi』 in Music Program of the 23rd International Society for Music Information Retrieval Conference (ISMIR) (2022)</li>
-          <li>Virtual production | 『Not at home』 Sound Designer (2022)</li>
-          <li>Art Film | 『To my mojave』 Sound, Performance (2021)</li>
-          <li>Performance | 『Chosunilbo Debut Concerts』 (2021)</li>
-          <li>Performance | SNU Orient Express EXM (2021)</li>
-          <li>Performance | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</li>
-          <li>Performance | Poongryu-jeon 『Empoong-nongwol』 (2021)</li>
-        </ul>
-      </section>
-      <section id="support">
-        <h2>Support program</h2>
-        <ul>
-          <li>ARKO Travel for Research Abroad, Canada, Montreal (2023)</li>
-          <li>ARKO International Art Fund Project, Korean x Canada research project (2023)</li>
         </ul>
       </section>
     </main>

--- a/index_ko.html
+++ b/index_ko.html
@@ -24,9 +24,7 @@
         <a href="#publications">연구</a>
       <a href="#talks">발표</a>
         <a href="#prize">수상</a>
-      <a href="#honors">장학</a>
-      <a href="#projects">프로젝트</a>
-      <a href="#support">지원</a>
+      <a href="project.html" class="project-link">프로젝트</a>
     </nav>
     <main class="content">
       <section id="cover">
@@ -151,47 +149,6 @@
           <li>제20회 인천국악대축제 1등 (2020)</li>
           <li>제35·36회 동아국악콩쿠르 3등 (2019, 2020)</li>
           <li>제4회 영산국악콩쿠르 1등 (2020)</li>
-        </ul>
-      </section>
-
-      <section id="honors">
-        <h2>장학 및 포상</h2>
-        <ul>
-          <li>
-            
-            페르노리카르 한국전통음악 장학금
-          </li>
-          <li>
-            
-            <strong>서울대학교</strong><br>수석 졸업; 전공 1위<br>등록금 전액 면제 (2017–2019) <br>학업 우수 장학금 (2020) 
-          </li>
-          <li>
-            
-            <strong>서강대학교</strong><br>대학원생 우수 장학금 (2022 - 2023) 
-          </li>
-        </ul>
-      </section>
-
-      <section id="projects">
-        <h2>프로젝트</h2>
-        <ul>
-          <li>프로젝트 | 국립국악원과 협업, AI를 활용한 한국 고음악 복원 (2024)</li>
-          <li>전시 | 『FLOW』 프로듀서, 사운드 디자이너 (2023)</li>
-          <li>공연 | 제23회 국제 음악정보검색학회(ISMIR) 음악 프로그램 『Fantastic AI Sinawi』 (2022)</li>
-          <li>버추얼 프로덕션 | 『Not at home』 사운드 디자이너 (2022)</li>
-          <li>아트 필름 | 『To my mojave』 사운드, 퍼포먼스 (2021)</li>
-          <li>공연 | 『조선일보 신인음악회』 (2021)</li>
-          <li>공연 | 서울대 오리엔트 익스프레스 EXM (2021)</li>
-          <li>공연 | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</li>
-          <li>공연 | 풍류전 『음풍농월』 (2021)</li>
-        </ul>
-      </section>
-
-      <section id="support">
-        <h2>지원 프로그램</h2>
-        <ul>
-          <li>ARKO 해외 리서치 트립 지원, 캐나다 몬트리올 (2023)</li>
-          <li>ARKO 국제예술기금 프로젝트, 한국-캐나다 연구 프로젝트 (2023)</li>
         </ul>
       </section>
 

--- a/project.html
+++ b/project.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Projects - Danbinaerin Han</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+</head>
+<body class="lang-en">
+  <div class="lang-switch">
+    <button id="switch-ko">한국어</button>
+    <button id="switch-en">English</button>
+  </div>
+  <div class="layout">
+    <nav class="sidebar">
+      <div class="profile">
+        <img src="images/profile.png" alt="Danbinaerin Han">
+      </div>
+      <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
+      <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
+      <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
+      <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+      <a href="project.html" class="project-link"><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></a>
+    </nav>
+    <main class="content">
+      <h1><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></h1>
+      <ul>
+        <li>
+          <span class="lang-en">Project | Restoration Korean Old Music using AI, collaboration with National Gugak Center (2024)</span>
+          <span class="lang-ko">프로젝트 | 국립국악원과 협업, AI를 활용한 한국 고음악 복원 (2024)</span>
+        </li>
+        <li>
+          <span class="lang-en">Exhibition | 『FLOW』 Producer, Sound designer (2023)</span>
+          <span class="lang-ko">전시 | 『FLOW』 프로듀서, 사운드 디자이너 (2023)</span>
+        </li>
+        <li>
+          <span class="lang-en">Performance | 『Fantastic AI Sinawi』 in Music Program of the 23rd International Society for Music Information Retrieval Conference (ISMIR) (2022)</span>
+          <span class="lang-ko">공연 | 제23회 국제 음악정보검색학회(ISMIR) 음악 프로그램 『Fantastic AI Sinawi』 (2022)</span>
+        </li>
+        <li>
+          <span class="lang-en">Virtual production | 『Not at home』 Sound Designer (2022)</span>
+          <span class="lang-ko">버추얼 프로덕션 | 『Not at home』 사운드 디자이너 (2022)</span>
+        </li>
+        <li>
+          <span class="lang-en">Art Film | 『To my mojave』 Sound, Performance (2021)</span>
+          <span class="lang-ko">아트 필름 | 『To my mojave』 사운드, 퍼포먼스 (2021)</span>
+        </li>
+        <li>
+          <span class="lang-en">Performance | 『Chosunilbo Debut Concerts』 (2021)</span>
+          <span class="lang-ko">공연 | 『조선일보 신인음악회』 (2021)</span>
+        </li>
+        <li>
+          <span class="lang-en">Performance | SNU Orient Express EXM (2021)</span>
+          <span class="lang-ko">공연 | 서울대 오리엔트 익스프레스 EXM (2021)</span>
+        </li>
+        <li>
+          <span class="lang-en">Performance | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span>
+          <span class="lang-ko">공연 | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span>
+        </li>
+        <li>
+          <span class="lang-en">Performance | Poongryu-jeon 『Empoong-nongwol』 (2021)</span>
+          <span class="lang-ko">공연 | 풍류전 『음풍농월』 (2021)</span>
+        </li>
+      </ul>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>
+

--- a/research.html
+++ b/research.html
@@ -22,6 +22,7 @@
       <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
       <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>
       <a href="research.html"><span class="lang-en">Research</span><span class="lang-ko">연구</span></a>
+      <a href="project.html" class="project-link"><span class="lang-en">Projects</span><span class="lang-ko">프로젝트</span></a>
     </nav>
     <main class="content">
       <div class="page-header">

--- a/style.css
+++ b/style.css
@@ -82,6 +82,12 @@ body {
   color: #bf360c;
 }
 
+.sidebar a.project-link {
+  margin: 16px 0;
+  background: #ffe0b2;
+  color: #bf360c;
+}
+
 .content {
   margin-left: 240px;
   padding: 60px 40px 40px;


### PR DESCRIPTION
## Summary
- remove honors/scholarship and support sections from both language landing pages
- add dedicated projects page and sidebar link with distinct styling
- update navigation across pages for new projects page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06e3bb548832eb21ab98c88605b87