### PR TITLE
Expand research section and add project details

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,22 +63,16 @@
       <section id="research">
         <h2>Research</h2>
         <div class="research-topic">
-          <div class="topic-header">
-            <h3>Analyzing Korean Folk Song</h3>
-            <button class="more-btn" data-target="topic1">More</button>
-          </div>
-          <div id="topic1" class="more-content">
+          <h3>Analyzing Korean Folk Song</h3>
+          <div id="topic1">
             <ul>
               <li>Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, in Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</li>
             </ul>
           </div>
         </div>
         <div class="research-topic">
-          <div class="topic-header">
-            <h3>Korean Traditional Music Generation</h3>
-            <button class="more-btn" data-target="topic2">More</button>
-          </div>
-          <div id="topic2" class="more-content">
+          <h3>Korean Traditional Music Generation</h3>
+          <div id="topic2">
             <ul>
               <li>Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding” in Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024 <strong>Best Paper Award</strong></li>
               <li>Danbinaerin Han, Daewoong Kim, Dasaem Jeong, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, in Proc. of 10th Digital Library for Music(DLfM), 2023</li>

--- a/index_ko.html
+++ b/index_ko.html
@@ -101,22 +101,16 @@
         <section id="research">
           <h2>연구</h2>
           <div class="research-topic">
-            <div class="topic-header">
-              <h3>한국 민요 분석</h3>
-              <button class="more-btn" data-target="topic1-ko">더보기</button>
-            </div>
-            <div id="topic1-ko" class="more-content">
+            <h3>한국 민요 분석</h3>
+            <div id="topic1-ko">
               <ul>
                 <li>한단비내린, Rafael Caro Repetto, 정다샘, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, 제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023</li>
               </ul>
             </div>
           </div>
           <div class="research-topic">
-            <div class="topic-header">
-              <h3>한국 전통음악 생성</h3>
-              <button class="more-btn" data-target="topic2-ko">더보기</button>
-            </div>
-            <div id="topic2-ko" class="more-content">
+            <h3>한국 전통음악 생성</h3>
+            <div id="topic2-ko">
               <ul>
                 <li>한단비내린, Mark Gotham, 김동민, 박한나, 이시훈, 정다샘, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding”, 제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024 <strong>최우수 논문상</strong></li>
                 <li>한단비내린, 김대웅, 정다샘, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, 제10회 음악 디지털 라이브러리 학회(DLfM) 논문집, 2023</li>

--- a/project.html
+++ b/project.html
@@ -35,35 +35,8 @@
           <span class="lang-en">Exhibition | 『FLOW』 Producer, Sound designer (2023)</span>
           <span class="lang-ko">전시 | 『FLOW』 프로듀서, 사운드 디자이너 (2023)</span>
         </li>
-        <li>
-          <span class="lang-en">Performance | 『Fantastic AI Sinawi』 in Music Program of the 23rd International Society for Music Information Retrieval Conference (ISMIR) (2022)</span>
-          <span class="lang-ko">공연 | 제23회 국제 음악정보검색학회(ISMIR) 음악 프로그램 『Fantastic AI Sinawi』 (2022)</span>
-        </li>
-        <li>
-          <span class="lang-en">Virtual production | 『Not at home』 Sound Designer (2022)</span>
-          <span class="lang-ko">버추얼 프로덕션 | 『Not at home』 사운드 디자이너 (2022)</span>
-        </li>
-        <li>
-          <span class="lang-en">Art Film | 『To my mojave』 Sound, Performance (2021)</span>
-          <span class="lang-ko">아트 필름 | 『To my mojave』 사운드, 퍼포먼스 (2021)</span>
-        </li>
-        <li>
-          <span class="lang-en">Performance | 『Chosunilbo Debut Concerts』 (2021)</span>
-          <span class="lang-ko">공연 | 『조선일보 신인음악회』 (2021)</span>
-        </li>
-        <li>
-          <span class="lang-en">Performance | SNU Orient Express EXM (2021)</span>
-          <span class="lang-ko">공연 | 서울대 오리엔트 익스프레스 EXM (2021)</span>
-        </li>
-        <li>
-          <span class="lang-en">Performance | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span>
-          <span class="lang-ko">공연 | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span>
-        </li>
-        <li>
-          <span class="lang-en">Performance | Poongryu-jeon 『Empoong-nongwol』 (2021)</span>
-          <span class="lang-ko">공연 | 풍류전 『음풍농월』 (2021)</span>
-        </li>
       </ul>
+      <a href="project_detail.html" class="more-btn"><span class="lang-en">Details</span><span class="lang-ko">상세보기</span></a>
     </main>
   </div>
   <script src="script.js"></script>

--- a/project_detail.html
+++ b/project_detail.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Project Details - Danbinaerin Han</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+</head>
+<body class="lang-en">
+  <div class="lang-switch">
+    <button id="switch-ko">한국어</button>
+    <button id="switch-en">English</button>
+  </div>
+  <main class="content" style="margin-left:0;">
+    <a href="project.html" class="more-btn"><span class="lang-en">Back</span><span class="lang-ko">뒤로</span></a>
+    <h1><span class="lang-en">Project Details</span><span class="lang-ko">프로젝트 상세</span></h1>
+    <ul>
+      <li>
+        <span class="lang-en">Project | Restoration Korean Old Music using AI, collaboration with National Gugak Center (2024)</span>
+        <span class="lang-ko">프로젝트 | 국립국악원과 협업, AI를 활용한 한국 고음악 복원 (2024)</span>
+      </li>
+      <li>
+        <span class="lang-en">Exhibition | 『FLOW』 Producer, Sound designer (2023)</span>
+        <span class="lang-ko">전시 | 『FLOW』 프로듀서, 사운드 디자이너 (2023)</span>
+      </li>
+      <li>
+        <span class="lang-en">Performance | 『Fantastic AI Sinawi』 in Music Program of the 23rd International Society for Music Information Retrieval Conference (ISMIR) (2022)</span>
+        <span class="lang-ko">공연 | 제23회 국제 음악정보검색학회(ISMIR) 음악 프로그램 『Fantastic AI Sinawi』 (2022)</span>
+      </li>
+      <li>
+        <span class="lang-en">Virtual production | 『Not at home』 Sound Designer (2022)</span>
+        <span class="lang-ko">버추얼 프로덕션 | 『Not at home』 사운드 디자이너 (2022)</span>
+      </li>
+      <li>
+        <span class="lang-en">Art Film | 『To my mojave』 Sound, Performance (2021)</span>
+        <span class="lang-ko">아트 필름 | 『To my mojave』 사운드, 퍼포먼스 (2021)</span>
+      </li>
+      <li>
+        <span class="lang-en">Performance | 『Chosunilbo Debut Concerts』 (2021)</span>
+        <span class="lang-ko">공연 | 『조선일보 신인음악회』 (2021)</span>
+      </li>
+      <li>
+        <span class="lang-en">Performance | SNU Orient Express EXM (2021)</span>
+        <span class="lang-ko">공연 | 서울대 오리엔트 익스프레스 EXM (2021)</span>
+      </li>
+      <li>
+        <span class="lang-en">Performance | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span>
+        <span class="lang-ko">공연 | ARKO Art & Tech Festival &lt;Nothing Makes Itself&gt; (2021)</span>
+      </li>
+      <li>
+        <span class="lang-en">Performance | Poongryu-jeon 『Empoong-nongwol』 (2021)</span>
+        <span class="lang-ko">공연 | 풍류전 『음풍농월』 (2021)</span>
+      </li>
+    </ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/research.html
+++ b/research.html
@@ -27,13 +27,8 @@
     <main class="content">
       <div class="page-header">
         <h1><span class="lang-en">Research</span><span class="lang-ko">연구</span></h1>
-        <button class="more-btn" data-target="pub-list">
-          <span class="lang-en">More</span>
-          <span class="lang-ko">더보기</span>
-          <i class="fa-solid fa-chevron-down"></i>
-        </button>
       </div>
-      <div id="pub-list" class="more-content">
+      <div id="pub-list">
         <ul>
           <li>
             <span class="lang-en"><strong>Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</strong><br>Jiyoon Kim, et al., ISMIR 2024</span>

--- a/script.js
+++ b/script.js
@@ -35,14 +35,4 @@ document.addEventListener('DOMContentLoaded', function() {
       activateSidebar();
     }
 
-  const moreButtons = document.querySelectorAll('.more-btn');
-  moreButtons.forEach(btn => {
-    btn.addEventListener('click', () => {
-      const target = document.getElementById(btn.dataset.target);
-      if (target) {
-        target.classList.toggle('open');
-        btn.classList.toggle('open');
-      }
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- Remove collapsible "More" buttons from research sections so publications are always visible
- Show only two representative projects with a Details link to a new full project page
- Add standalone project detail page with back navigation button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a071c9ace4832e9fb9092b47e6920e