### PR TITLE
style: adjust section headings and profile styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -53,11 +53,13 @@ body.lang-ko .lang-en { display: none; }
 }
 
 .sidebar .profile {
-  width: 80px;
-  height: 80px;
+  width: 120px;
+  height: 120px;
   margin: 0 auto 20px;
   border-radius: 50%;
   overflow: hidden;
+  border: 3px solid #e65100;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
 }
 
 .sidebar .profile img {
@@ -65,8 +67,6 @@ body.lang-ko .lang-en { display: none; }
   height: 100%;
   object-fit: cover;
   object-position: top;
-  transform: scale(1.3);
-  transform-origin: top center;
 }
 
 .sidebar a {
@@ -98,6 +98,20 @@ body.lang-ko .lang-en { display: none; }
   color: #1b5e20;
 }
 
+/* adjust sidebar link sizes by importance */
+.sidebar a[href="#education"] {
+  font-size: 1.1rem;
+}
+
+.sidebar a[href="#research"] {
+  font-size: 1.05rem;
+}
+
+.sidebar a[href="#talks"],
+.sidebar a[href="#prize"] {
+  font-size: 1rem;
+}
+
 .content {
   margin-left: 240px;
   padding: 60px 40px 40px;
@@ -119,6 +133,23 @@ h2 {
   margin-top: 40px;
   color: #e65100;
   text-align: left;
+}
+
+/* section heading sizes based on importance */
+#education h2 {
+  font-size: 2rem;
+}
+
+#research h2 {
+  font-size: 1.8rem;
+}
+
+#talks h2 {
+  font-size: 1.6rem;
+}
+
+#prize h2 {
+  font-size: 1.5rem;
 }
 
 ul { padding-left: 20px; }


### PR DESCRIPTION
## Summary
- tweak sidebar profile photo to improve quality and add border/shadow
- vary sidebar link and section heading sizes based on importance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a077745fc8832e98b34baa2a09eeb0