### PR TITLE
Refine sidebar layout and rename project section

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,13 +17,12 @@
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
-      <a href="#cover">Cover</a>
       <a href="#news">News</a>
       <a href="#education">Education</a>
       <a href="#research">Research</a>
       <a href="#talks">Talks</a>
       <a href="#prize">Prize</a>
-      <a href="project_detail.html" class="project-link">Projects</a>
+      <a href="project_detail.html" class="project-link">Bittering Danbi</a>
     </nav>
     <main class="content">
       <section id="cover">
@@ -105,7 +104,7 @@
         </ul>
       </section>
       <section id="projects">
-        <h2>Projects</h2>
+        <h2>Bittering Danbi</h2>
         <ul>
           <li>Project | Restoration Korean Old Music using AI, collaboration with National Gugak Center (2024)</li>
           <li>Exhibition | 『FLOW』 Producer, Sound designer (2023)</li>

--- a/index_ko.html
+++ b/index_ko.html
@@ -17,13 +17,12 @@
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
-        <a href="#cover">한단비내린</a>
         <a href="#news">소식</a>
         <a href="#education">학력</a>
         <a href="#publications">연구</a>
       <a href="#talks">발표</a>
       <a href="#prize">수상</a>
-      <a href="project_detail.html" class="project-link">프로젝트</a>
+      <a href="project_detail.html" class="project-link">Bittering Danbi</a>
     </nav>
     <main class="content">
       <section id="cover">
@@ -145,7 +144,7 @@
         </ul>
       </section>
       <section id="projects">
-        <h2>프로젝트</h2>
+        <h2>Bittering Danbi</h2>
         <ul>
           <li>프로젝트 | 국립국악원과 협업, AI를 활용한 한국 고음악 복원 (2024)</li>
           <li>전시 | 『FLOW』 프로듀서, 사운드 디자이너 (2023)</li>

--- a/project_detail.html
+++ b/project_detail.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Project Details - Danbinaerin Han</title>
+  <title>Bittering Danbi - Danbinaerin Han</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
   <link rel="stylesheet" href="style.css">
@@ -14,7 +14,7 @@
   </div>
   <main class="content" style="margin-left:0;">
     <a href="index.html" class="home-btn"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
-    <h1><span class="lang-en">Project Details</span><span class="lang-ko">프로젝트 상세</span></h1>
+    <h1><span class="lang-en">Bittering Danbi</span><span class="lang-ko">Bittering Danbi</span></h1>
     <ul>
       <li>
         <span class="lang-en">Project | Restoration Korean Old Music using AI, collaboration with National Gugak Center (2024)</span>

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body.lang-ko .lang-en { display: none; }
 .layout { display: flex; }
 
 .sidebar {
-  width: 240px;
+  width: 200px;
   background: #fff9ef;
   height: 100vh;
   position: fixed;
@@ -89,12 +89,10 @@ body.lang-ko .lang-en { display: none; }
 
 .sidebar a.project-link {
   margin: 16px 0;
-  background: #c8e6c9;
   color: #2e7d32;
 }
 
 .sidebar a.project-link:hover {
-  background: #a5d6a7;
   color: #1b5e20;
 }
 
@@ -113,7 +111,7 @@ body.lang-ko .lang-en { display: none; }
 }
 
 .content {
-  margin-left: 240px;
+  margin-left: 200px;
   padding: 60px 40px 40px;
   max-width: 900px;
 }
@@ -253,6 +251,7 @@ p {
     width: 100%;
     height: auto;
     flex-direction: row;
+    flex-wrap: nowrap;
     overflow-x: auto;
     border-right: none;
     border-bottom: 2px solid #ffd59d;
@@ -263,6 +262,8 @@ p {
   }
   .sidebar a {
     padding: 10px 16px;
+    flex: 0 0 auto;
+    white-space: nowrap;
   }
   .content { margin-left: 0; padding: 20px; }
 }


### PR DESCRIPTION
## Summary
- Shrink sidebar width and remove Cover link
- Rename Project section to "Bittering Danbi" with green text only
- Improve mobile sidebar flow with horizontal scrolling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a079106b10832e9a3b3ad629a5363b