### PR TITLE
Adjust education nav font and soften profile image

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,15 +58,16 @@ body.lang-ko .lang-en { display: none; }
   margin: 0 auto 20px;
   border-radius: 50%;
   overflow: hidden;
-  border: 3px solid #e65100;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
+  border: 2px solid #ffcc80;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.1);
 }
 
 .sidebar .profile img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: top;
+  object-position: center;
+  transform: scale(1.1);
 }
 
 .sidebar a {
@@ -75,6 +76,7 @@ body.lang-ko .lang-en { display: none; }
   text-decoration: none;
   font-weight: 600;
   border-radius: 4px;
+  font-size: 1rem;
 }
 
 .sidebar a:hover {
@@ -96,19 +98,7 @@ body.lang-ko .lang-en { display: none; }
   color: #1b5e20;
 }
 
-/* adjust sidebar link sizes by importance */
-.sidebar a[href="#education"] {
-  font-size: 1.1rem;
-}
-
-.sidebar a[href="#research"] {
-  font-size: 1.05rem;
-}
-
-.sidebar a[href="#talks"],
-.sidebar a[href="#prize"] {
-  font-size: 1rem;
-}
+/* sidebar links have uniform size */
 
 .content {
   margin-left: 200px;


### PR DESCRIPTION
## Summary
- Standardize sidebar link font sizes so Education matches other navigation items
- Lighten profile photo border, center the image, and crop by scaling to hide excess left area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a080d5a994832ebdf8323c3c9768ab