### PR TITLE
Add keyword tags and refine layout colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,11 @@
       <section id="cover">
         <div>
           <h1>Danbinaerin Han</h1>
-          <p>Korean traditional music, music information retrieval, computational musicology, Haegeum player</p>
+          <div class="keywords">
+            <span class="keyword">Korean traditional music</span>
+            <span class="keyword">music information retrieval</span>
+            <span class="keyword">computational musicology</span>
+          </div>
           <p>I am a PhD student in the Music and Audio Computing Lab under Prof. Juhan Nam.<br>
             I explore "what is Korean music" using MIR techniques.</p>
           <p><strong>E-mail:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>

--- a/index_ko.html
+++ b/index_ko.html
@@ -26,13 +26,17 @@
     </nav>
     <main class="content">
       <section id="cover">
-        
+
           <div>
             <h1>한 단비내린</h1>
+            <div class="keywords">
+              <span class="keyword">한국 전통음악</span>
+              <span class="keyword">음악정보검색</span>
+              <span class="keyword">전산음악학</span>
+            </div>
             <p><strong>안녕하세요, 한단비내린입니다</strong></p>
             <p>Music and Audio Computing Lab(MACLab)의 박사과정 학생입니다.<br>
               MIR(Music Information Retrieval) 기법을 활용하여 '한국 음악이 무엇인가'를 탐구하고 있습니다.</p>
-              <p>한국 전통음악, 음악정보검색, 전산음악학, 해금 연주자</p>
             <p><strong>이메일:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
               <div class="social-icons">
                 <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="이력서" target="_blank"><i class="fa-solid fa-file"></i></a>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'NanumSquare', sans-serif;
-  background: #fffbf5;
+  background: #fffdf8;
   margin: 0;
   color: #333;
   line-height: 1.6;
@@ -41,7 +41,7 @@ body.lang-ko .lang-en { display: none; }
 
 .sidebar {
   width: 200px;
-  background: #fff9ef;
+  background: #ffe3c4;
   height: 100vh;
   position: fixed;
   top: 0;
@@ -49,7 +49,7 @@ body.lang-ko .lang-en { display: none; }
   padding-top: 80px;
   display: flex;
   flex-direction: column;
-  border-right: 2px solid #ffe5c1;
+  border-right: 2px solid #ffcb8e;
 }
 
 .sidebar .profile {
@@ -104,6 +104,23 @@ body.lang-ko .lang-en { display: none; }
   margin-left: 200px;
   padding: 60px 40px 40px;
   max-width: 900px;
+}
+
+.keywords {
+  margin-top: 4px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.keyword {
+  background: #ffe0b2;
+  color: #bf360c;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
 .section { margin-bottom: 40px; }
@@ -244,7 +261,7 @@ p {
     flex-wrap: nowrap;
     overflow-x: auto;
     border-right: none;
-    border-bottom: 2px solid #ffd59d;
+    border-bottom: 2px solid #ffcb8e;
     padding: 10px 0;
   }
   .sidebar .profile {


### PR DESCRIPTION
## Summary
- Add stylized keyword tags beneath the profile name on both English and Korean homepages
- Increase contrast between sidebar and content with updated color palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a087f80860832ea8876f203447291e