### PR TITLE
Unify sidebar theme and heading sizes

### DIFF
--- a/education.html
+++ b/education.html
@@ -9,7 +9,7 @@
 </head>
 <body class="lang-en">
   <div class="lang-switch">
-    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i></button>
+    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i><span class="lang-text">가/A</span></button>
   </div>
   <div class="layout">
     <nav class="sidebar">

--- a/experience.html
+++ b/experience.html
@@ -9,7 +9,7 @@
 </head>
 <body class="lang-en">
   <div class="lang-switch">
-    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i></button>
+    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i><span class="lang-text">가/A</span></button>
   </div>
   <div class="layout">
     <nav class="sidebar">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="lang-switch">
-    <a href="index_ko.html" class="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i></a>
+    <a href="index_ko.html" class="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i><span class="lang-text">가/A</span></a>
   </div>
   <div class="layout">
     <nav class="sidebar">

--- a/index_ko.html
+++ b/index_ko.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="lang-switch">
-    <a href="index.html" class="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i></a>
+    <a href="index.html" class="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i><span class="lang-text">가/A</span></a>
   </div>
   <div class="layout">
     <nav class="sidebar">

--- a/project_detail.html
+++ b/project_detail.html
@@ -10,7 +10,7 @@
 </head>
 <body class="lang-en">
   <div class="lang-switch">
-    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i></button>
+    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i><span class="lang-text">가/A</span></button>
   </div>
   <main class="content" style="margin-left:0;">
     <a href="index.html" class="home-btn"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>

--- a/research.html
+++ b/research.html
@@ -10,7 +10,7 @@
 </head>
 <body class="lang-en">
   <div class="lang-switch">
-    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i></button>
+    <button id="lang-toggle" aria-label="Switch language"><i class="fa-solid fa-globe"></i><span class="lang-text">가/A</span></button>
   </div>
   <div class="layout">
     <nav class="sidebar">

--- a/script.js
+++ b/script.js
@@ -35,7 +35,6 @@ document.addEventListener("DOMContentLoaded", function () {
       });
       if (!found) {
         sidebarLinks.forEach((link) => link.classList.remove("active"));
-        sidebarLinks[sections.length - 1].classList.add("active");
       }
     };
     window.addEventListener("scroll", activateSidebar);

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ body.lang-ko .lang-en {
 .lang-switch a,
 .lang-switch button {
   margin-left: 8px;
-  padding: 6px 12px;
+  padding: 4px 8px;
   border: 2px solid #ffb74d;
   background: #fff;
   color: #e65100;
@@ -35,6 +35,8 @@ body.lang-ko .lang-en {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  font-size: 0.8rem;
+  gap: 4px;
 }
 
 .lang-switch a:hover,
@@ -43,13 +45,17 @@ body.lang-ko .lang-en {
   color: #fff;
 }
 
+.lang-switch .lang-text {
+  font-size: 0.8rem;
+}
+
 .layout {
   display: flex;
 }
 
 .sidebar {
   width: 200px;
-  background: #3e2723;
+  background: #ffe0b2;
   height: 100vh;
   position: fixed;
   top: 0;
@@ -57,7 +63,7 @@ body.lang-ko .lang-en {
   padding-top: 80px;
   display: flex;
   flex-direction: column;
-  border-right: 2px solid #5d4037;
+  border-right: 2px solid #ffb74d;
 }
 
 .sidebar .profile {
@@ -66,7 +72,7 @@ body.lang-ko .lang-en {
   margin: 0 auto 20px;
   border-radius: 50%;
   overflow: hidden;
-  border: 2px solid #ffcc80;
+  border: 2px solid #ffb74d;
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.1);
 }
 
@@ -80,7 +86,7 @@ body.lang-ko .lang-en {
 
 .sidebar a {
   padding: 12px 20px;
-  color: #fff3e0;
+  color: #bf360c;
   text-decoration: none;
   font-weight: 600;
   border-radius: 4px;
@@ -88,22 +94,22 @@ body.lang-ko .lang-en {
 }
 
 .sidebar a:hover {
-  background: #5d4037;
-  color: #fff;
+  background: #ffcc80;
+  color: #bf360c;
 }
 
 .sidebar a.active {
-  background: #795548;
+  background: #ffb74d;
   color: #fff;
 }
 
 .sidebar a.project-link {
   margin: 16px 0;
-  color: #2e7d32;
+  color: #e65100;
 }
 
 .sidebar a.project-link:hover {
-  color: #1b5e20;
+  color: #bf360c;
 }
 
 /* sidebar links have uniform size */
@@ -112,6 +118,11 @@ body.lang-ko .lang-en {
   margin-left: 200px;
   padding: 60px 40px 40px;
   max-width: 900px;
+}
+
+.content section + section {
+  border-top: 2px solid #ffb74d;
+  padding-top: 40px;
 }
 
 .keywords {
@@ -148,27 +159,11 @@ h2 {
   margin-top: 40px;
   color: #e65100;
   text-align: left;
-}
-
-/* section heading sizes based on importance */
-#education h2 {
-  font-size: 2rem;
-}
-
-#research h2 {
   font-size: 1.8rem;
 }
 
-#talks h2 {
-  font-size: 1.6rem;
-}
-
-#prize h2 {
-  font-size: 1.5rem;
-}
-
 #news h2 {
-  font-size: 1.4rem;
+  font-size: 2rem;
 }
 
 #news li {
@@ -320,7 +315,7 @@ p {
     flex-wrap: nowrap;
     overflow-x: auto;
     border-right: none;
-    border-bottom: 2px solid #ffcb8e;
+    border-bottom: 2px solid #ffb74d;
     padding: 10px 0;
   }
   .sidebar .profile {


### PR DESCRIPTION
## Summary
- Match sidebar colors and highlight tones with main content
- Unify section heading sizes (except News) and add separators between sections
- Show language toggle text `가/A` next to globe and prevent sidebar from highlighting at top of page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a09692e1ac832e9e6e0394b5912cd9