### PR TITLE
Add copyright footer and refine research listings

### DIFF
--- a/education.html
+++ b/education.html
@@ -34,9 +34,10 @@
           <span class="lang-ko"><strong>KAIST</strong> – 컴퓨터공학 학사, 2020–2024</span>
         </li>
       </ul>
-    </main>
-  </div>
-  <script src="script.js"></script>
-</body>
+      </main>
+    </div>
+    <footer class="footer">COPYRIGHT © 2025 Danbinaerin Han</footer>
+    <script src="script.js"></script>
+  </body>
 </html>
 

--- a/experience.html
+++ b/experience.html
@@ -34,9 +34,10 @@
           <span class="lang-ko"><strong>AI 스타트업</strong> – 소프트웨어 엔지니어 인턴, 2023년 여름</span>
         </li>
       </ul>
-    </main>
-  </div>
-  <script src="script.js"></script>
-</body>
+      </main>
+    </div>
+    <footer class="footer">COPYRIGHT © 2025 Danbinaerin Han</footer>
+    <script src="script.js"></script>
+  </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -70,12 +70,11 @@
           <h3>Analyzing Korean Folk Song</h3>
           <div id="topic1">
             <ul>
-              <li class="paper-entry">
-                <div class="paper-title">Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song</div>
-                <div class="paper-authors">Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong</div>
-                <div class="paper-venue"><em>Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</em></div>
-                <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a>
-              </li>
+                <li class="paper-entry">
+                  <div class="paper-title">Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">Danbinaerin Han, Rafael Caro Repetto, Dasaem Jeong</div>
+                  <div class="paper-venue"><em>Proc. of the 24th International Society for Music Information Retrieval Conference (ISMIR), 2023</em></div>
+                </li>
             </ul>
           </div>
         </div>
@@ -83,24 +82,21 @@
           <h3>Korean Traditional Music Generation</h3>
           <div id="topic2">
             <ul>
-              <li class="paper-entry">
-                <div class="paper-title">Six dragons fly again: Reviving 15th-century Korean court music with transformers and novel encoding</div>
-                <div class="paper-authors">Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong</div>
-                <div class="paper-venue"><em>Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024</em> <strong>Best Paper Award</strong></div>
-                <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a>
-              </li>
-              <li class="paper-entry">
-                <div class="paper-title">Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper</div>
-                <div class="paper-authors">Danbinaerin Han, Daewoong Kim, Dasaem Jeong</div>
-                <div class="paper-venue"><em>Proc. of 10th Digital Library for Music (DLfM), 2023</em></div>
-                <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a>
-              </li>
-              <li class="paper-entry">
-                <div class="paper-title">Fantastic AI Sinawi: Composing Korean Traditional Music Using Deep Neural Networks</div>
-                <div class="paper-authors">Hannah Park, Danbinaerin Han, Chaeryung Oh, Dasaem Jeong</div>
-                <div class="paper-venue"><em>Journal of Digital Contents Society, 2023</em></div>
-                <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a>
-              </li>
+                <li class="paper-entry">
+                  <div class="paper-title">Six dragons fly again: Reviving 15th-century Korean court music with transformers and novel encoding <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong</div>
+                  <div class="paper-venue"><em>Proc. of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024</em> <strong>Best Paper Award</strong></div>
+                </li>
+                <li class="paper-entry">
+                  <div class="paper-title">Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">Danbinaerin Han, Daewoong Kim, Dasaem Jeong</div>
+                  <div class="paper-venue"><em>Proc. of 10th Digital Library for Music (DLfM), 2023</em></div>
+                </li>
+                <li class="paper-entry">
+                  <div class="paper-title">Fantastic AI Sinawi: Composing Korean Traditional Music Using Deep Neural Networks <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">Hannah Park, Danbinaerin Han, Chaeryung Oh, Dasaem Jeong</div>
+                  <div class="paper-venue"><em>Journal of Digital Contents Society, 2023</em></div>
+                </li>
             </ul>
           </div>
         </div>
@@ -138,7 +134,8 @@
         <a href="project_detail.html" class="more-btn">Details</a>
       </section>
     </main>
-  </div>
-  <script src="script.js"></script>
-</body>
-</html>
+    </div>
+    <footer class="footer">COPYRIGHT © 2025 Danbinaerin Han</footer>
+    <script src="script.js"></script>
+  </body>
+  </html>

--- a/index_ko.html
+++ b/index_ko.html
@@ -114,7 +114,11 @@
             <h3>한국 토속민요 분석</h3>
             <div id="topic1-ko">
               <ul>
-                <li>한단비내린, Rafael Caro Repetto, 정다샘, “Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song”, 제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023</li>
+                <li class="paper-entry">
+                  <div class="paper-title">Finding Tori: Self-Supervised Learning for Analyzing Korean Folk Song <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">한단비내린, Rafael Caro Repetto, 정다샘</div>
+                  <div class="paper-venue"><em>제24회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2023</em></div>
+                </li>
               </ul>
             </div>
           </div>
@@ -122,9 +126,21 @@
             <h3>한국 전통음악 생성</h3>
             <div id="topic2-ko">
               <ul>
-                <li>한단비내린, Mark Gotham, 김동민, 박한나, 이시훈, 정다샘, “Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding”, 제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024 <strong>최우수 논문상</strong></li>
-                <li>한단비내린, 김대웅, 정다샘, “Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper”, 제10회 음악 디지털 라이브러리 학회(DLfM) 논문집, 2023</li>
-                <li>박한나, 한단비내린, 오채령, 정다샘, “Fantastic AI Sinawi: 딥러닝을 활용한 한국 전통음악 작곡”, 디지털콘텐츠학회지, 2023</li>
+                <li class="paper-entry">
+                  <div class="paper-title">Six dragons fly again: Reviving 15th-century korean court music with transformers and novel encoding <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">한단비내린, Mark Gotham, 김동민, 박한나, 이시훈, 정다샘</div>
+                  <div class="paper-venue"><em>제25회 국제 음악 정보 검색 학회(ISMIR) 논문집, 2024</em> <strong>최우수 논문상</strong></div>
+                </li>
+                <li class="paper-entry">
+                  <div class="paper-title">Aligning Incomplete Lyrics of Korean Folk Song Dataset using Whisper <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">한단비내린, 김대웅, 정다샘</div>
+                  <div class="paper-venue"><em>제10회 음악 디지털 라이브러리 학회(DLfM) 논문집, 2023</em></div>
+                </li>
+                <li class="paper-entry">
+                  <div class="paper-title">Fantastic AI Sinawi: 딥러닝을 활용한 한국 전통음악 작곡 <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
+                  <div class="paper-authors">박한나, 한단비내린, 오채령, 정다샘</div>
+                  <div class="paper-venue"><em>디지털콘텐츠학회지, 2023</em></div>
+                </li>
               </ul>
             </div>
           </div>
@@ -164,8 +180,9 @@
         <a href="project_detail.html" class="more-btn">상세보기</a>
       </section>
 
-    </main>
-    </div>
-    <script src="script.js"></script>
-  </body>
-  </html>
+      </main>
+      </div>
+      <footer class="footer">COPYRIGHT © 2025 Danbinaerin Han</footer>
+      <script src="script.js"></script>
+    </body>
+    </html>

--- a/project_detail.html
+++ b/project_detail.html
@@ -53,7 +53,8 @@
         <span class="lang-ko">공연 | 풍류전 『음풍농월』 (2021)</span>
       </li>
     </ul>
-  </main>
-  <script src="script.js"></script>
-</body>
-</html>
+    </main>
+    <footer class="footer">COPYRIGHT © 2025 Danbinaerin Han</footer>
+    <script src="script.js"></script>
+  </body>
+  </html>

--- a/research.html
+++ b/research.html
@@ -31,34 +31,33 @@
         <ul>
           <li class="paper-entry">
             <div class="lang-en">
-              <div class="paper-title">Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding</div>
+              <div class="paper-title">Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
               <div class="paper-authors">Danbinaerin Han, Mark Gotham, Dongmin Kim, Hannah Park, Sihun Lee, Dasaem Jeong</div>
               <div class="paper-venue"><em>Proceedings of the 25th International Society for Music Information Retrieval Conference (ISMIR), 2024</em></div>
             </div>
             <div class="lang-ko">
-              <div class="paper-title">Six Dragons Fly Again: Transformers와 새로운 인코딩으로 15세기 한국 궁중음악 복원</div>
+              <div class="paper-title">Six Dragons Fly Again: Transformers와 새로운 인코딩으로 15세기 한국 궁중음악 복원 <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
               <div class="paper-authors">한단비나에린, 마크 고담, 김동민, 한나 박, 이시훈, 정다샘</div>
               <div class="paper-venue"><em>제25회 국제음악정보검색학회 (ISMIR) 논문집, 2024</em></div>
             </div>
-            <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a>
           </li>
           <li class="paper-entry">
             <div class="lang-en">
-              <div class="paper-title">Computational Analysis of Expressive Timing in Korean Traditional Jangdan</div>
+              <div class="paper-title">Computational Analysis of Expressive Timing in Korean Traditional Jangdan <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
               <div class="paper-authors">Jiyoon Kim, et al.</div>
               <div class="paper-venue"><em>International Computer Music Conference (ICMC), 2023</em></div>
             </div>
             <div class="lang-ko">
-              <div class="paper-title">한국 전통 장단의 표현적 타이밍에 대한 계산적 분석</div>
+              <div class="paper-title">한국 전통 장단의 표현적 타이밍에 대한 계산적 분석 <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a></div>
               <div class="paper-authors">김지윤 외</div>
               <div class="paper-venue"><em>국제컴퓨터음악학회 (ICMC), 2023</em></div>
             </div>
-            <a class="pdf-btn" href="https://arxiv.org/pdf/2408.01096" target="_blank">pdf</a>
           </li>
         </ul>
       </div>
     </main>
   </div>
+  <footer class="footer">COPYRIGHT © 2025 Danbinaerin Han</footer>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -219,15 +219,15 @@ p {
 
 .pdf-btn {
   display: inline-block;
-  margin-top: 4px;
-  padding: 4px 8px;
-  border: 2px solid #D96F32;
+  margin-left: 6px;
+  padding: 2px 6px;
+  border: 1px solid #D96F32;
   background: #F3E9DC;
   color: #D96F32;
   border-radius: 4px;
   font-weight: 600;
   text-decoration: none;
-  font-size: 0.9rem;
+  font-size: 0.75rem;
 }
 
 .pdf-btn:hover {
@@ -322,6 +322,14 @@ p {
 
 .more-btn.open i {
   transform: rotate(180deg);
+}
+
+.footer {
+  text-align: center;
+  margin-top: 40px;
+  padding: 20px 0;
+  font-size: 0.8rem;
+  color: #666;
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- Display PDF links beside paper titles with smaller buttons
- Separate title, author, and venue in Korean research listings
- Add site-wide footer with copyright text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4504114832e91b9cc6bf9deff81