### PR TITLE
Brighten text and add sidebar contact

### DIFF
--- a/education.html
+++ b/education.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body class="lang-en">
   <div class="lang-switch">
@@ -15,6 +16,10 @@
     <nav class="sidebar">
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
+      </div>
+      <div class="profile-info">
+        Danbinaerin Han (한국어로는 한단비내린)<br>
+        <i class="fa-solid fa-envelope"></i> naerin71@kaist.ac.kr
       </div>
       <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
       <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>

--- a/experience.html
+++ b/experience.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body class="lang-en">
   <div class="lang-switch">
@@ -15,6 +16,10 @@
     <nav class="sidebar">
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
+      </div>
+      <div class="profile-info">
+        Danbinaerin Han (한국어로는 한단비내린)<br>
+        <i class="fa-solid fa-envelope"></i> naerin71@kaist.ac.kr
       </div>
       <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
       <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
+      <div class="profile-info">
+        Danbinaerin Han (한국어로는 한단비내린)<br>
+        <i class="fa-solid fa-envelope"></i> naerin71@kaist.ac.kr
+      </div>
       <a href="#news">News</a>
       <a href="#education">Education</a>
       <a href="#research">Research</a>

--- a/index_ko.html
+++ b/index_ko.html
@@ -17,6 +17,10 @@
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
+      <div class="profile-info">
+        Danbinaerin Han (한국어로는 한단비내린)<br>
+        <i class="fa-solid fa-envelope"></i> naerin71@kaist.ac.kr
+      </div>
         <a href="#news">소식</a>
         <a href="#education">학력</a>
         <a href="#research">연구</a>

--- a/research.html
+++ b/research.html
@@ -17,6 +17,10 @@
       <div class="profile">
         <img src="images/profile.png" alt="Danbinaerin Han">
       </div>
+      <div class="profile-info">
+        Danbinaerin Han (한국어로는 한단비내린)<br>
+        <i class="fa-solid fa-envelope"></i> naerin71@kaist.ac.kr
+      </div>
       <a href="index.html"><span class="lang-en">Home</span><span class="lang-ko">홈</span></a>
       <a href="education.html"><span class="lang-en">Education</span><span class="lang-ko">학력</span></a>
       <a href="experience.html"><span class="lang-en">Experience</span><span class="lang-ko">경험</span></a>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@ body {
   font-family: "NanumSquare", sans-serif;
   background: #F3E9DC;
   margin: 0;
-  color: #333;
+  color: #444;
   line-height: 1.6;
   letter-spacing: 0.02em;
 }
@@ -83,6 +83,14 @@ body.lang-ko .lang-en {
   transform: scale(1.2);
 }
 
+.profile-info {
+  text-align: center;
+  color: #fff;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  margin: 0 10px 20px;
+}
+
 .sidebar a {
   padding: 12px 20px;
   color: #F3E9DC;
@@ -135,7 +143,7 @@ body.lang-ko .lang-en {
 
 .keyword {
   background: #F8B259;
-  color: #C75D2C;
+  color: #F3E9DC;
   padding: 4px 10px;
   border-radius: 12px;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- Lighten body and keyword text colors for improved readability
- Add small white contact info under sidebar profile image

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a6e8550c832eaa5c8f5cc0cd5e2c