### PR TITLE
Add cover figure image

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     </nav>
     <main class="content">
       <section id="cover">
-        <div>
+        <div class="cover-content">
           <h1>Danbinaerin Han</h1>
           <div class="keywords">
             <span class="keyword">Korean traditional music</span>
@@ -48,6 +48,7 @@
             <a href="https://instagram.com/handanbinaerin" class="icon" title="Instagram" target="_blank"><i class="fab fa-instagram"></i></a>
           </div>
         </div>
+        <img src="images/figure.png" alt="Cover image" class="cover-image">
       </section>
       <section id="news">
         <h2>🤗 News</h2>

--- a/index_ko.html
+++ b/index_ko.html
@@ -31,8 +31,7 @@
     </nav>
     <main class="content">
       <section id="cover">
-
-          <div>
+        <div class="cover-content">
             <h1>한 단비내린</h1>
             <div class="keywords">
               <span class="keyword">한국 전통음악</span>
@@ -49,8 +48,9 @@
               <a href="https://scholar.google.com/citations?user=4aSo2GAAAAAJ&hl=ko" class="icon" title="구글 스칼라" target="_blank"><i class="fa-solid fa-graduation-cap"></i></a>
               <a href="https://instagram.com/handanbinaerin" class="icon" title="인스타그램" target="_blank"><i class="fab fa-instagram"></i></a>
             </div>
-          </div>
-        </section>
+        </div>
+        <img src="images/figure.png" alt="표지 이미지" class="cover-image">
+      </section>
 
       <section id="news">
         <h2>🤗 소식</h2>

--- a/style.css
+++ b/style.css
@@ -245,6 +245,22 @@ p {
 
 #cover {
   padding: 80px 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.cover-content {
+  flex: 1;
+}
+
+.cover-image {
+  flex: 0 1 300px;
+  max-width: 300px;
+  width: 100%;
+  height: auto;
 }
 
 .topic-header,


### PR DESCRIPTION
## Summary
- Show `figure.png` beside the cover section on both English and Korean index pages
- Use flexbox layout and new styles to position the cover image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b0741c6c832e9e7b279a1eefc375