### PR TITLE
Update education sections with academic details

### DIFF
--- a/education.html
+++ b/education.html
@@ -31,12 +31,28 @@
       <h1><span class="lang-en">Education</span><span class="lang-ko">학력</span></h1>
       <ul>
         <li>
-          <span class="lang-en"><strong>Seoul National University</strong> – PhD in Music Education, 2024–Present</span>
-          <span class="lang-ko"><strong>서울대학교</strong> – 음악교육 박사과정, 2024–현재</span>
+          <span class="lang-en"><strong>Korea Advanced Institute of Science and Technology (KAIST)</strong> – Ph.D. Student, Graduate School of Culture Technology<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing Lab (MACLab)</a></em><br>Advisor: Prof. Juhan Nam</span>
+          <span class="lang-ko"><strong>한국과학기술원(KAIST) 문화기술대학원</strong> – 박사과정 재학<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing (MAC) Lab</a></em><br>지도교수: 남주한</span>
         </li>
         <li>
-          <span class="lang-en"><strong>KAIST</strong> – BS in Computer Science, 2020–2024</span>
-          <span class="lang-ko"><strong>KAIST</strong> – 컴퓨터공학 학사, 2020–2024</span>
+          <span class="lang-en"><strong>Sogang University</strong> – M.A. in Art and Technology<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>Advisor: Prof. Dasaem Jeong<br>GPA: 4.15 / 4.3</span>
+          <span class="lang-ko"><strong>서강대학교 아트앤테크놀로지학과</strong> – 예술과학 석사<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>지도교수: 정다샘<br>GPA: 4.15 / 4.3</span>
+        </li>
+        <li>
+          <span class="lang-en"><strong>Seoul National University</strong> – B.A. in Traditional Korean Music (Graduated with Highest Honors)<br>GPA: 4.08 / 4.3</span>
+          <span class="lang-ko"><strong>서울대학교 음악대학 국악과</strong> – 학사(수석졸업, 최우등졸업)<br>GPA: 4.08 / 4.3</span>
+        </li>
+        <li>
+          <span class="lang-en">Completed Teacher Certification Program in Music Education, College of Education, Seoul National University</span>
+          <span class="lang-ko">서울대학교 사범대학 음악교육과 교직 이수</span>
+        </li>
+        <li>
+          <span class="lang-en"><strong>National Gugak High School</strong> – Graduated with Highest Honors, Outstanding Major Award</span>
+          <span class="lang-ko"><strong>국립국악고등학교</strong> – 졸업(학교장상, 문화체육부장관상, 전공우수상)</span>
+        </li>
+        <li>
+          <span class="lang-en"><strong>National Gugak School</strong> – Graduated with Highest Honors, Outstanding Major Award</span>
+          <span class="lang-ko"><strong>국립국악학교</strong> – 졸업(학교장상, 국립국악원장상, 전공우수상)</span>
         </li>
       </ul>
       </main>

--- a/index.html
+++ b/index.html
@@ -64,10 +64,12 @@
       <section id="education">
         <h2>Education</h2>
         <ul>
-          <li><strong>Korea Advanced Institute of Science and Technology</strong> (2024.03~)<br>Music and Audio Computing (MAC) Lab | Advisor: Prof. Juhan Nam</li>
-          <li><strong>Sogang University</strong> (2022.03~2024.02)<br>GPA: 4.15 / 4.3</li>
-          <li><strong>Seoul National University</strong> (2017.03~2021.08)<br>GPA: 4.08 / 4.3</li>
-          <li><strong>National Gugak Middle & High School</strong> (2011.03~2017.02)<br>Graduated with Highest Honors, Outstanding Major Award</li>
+          <li><strong>Korea Advanced Institute of Science and Technology (KAIST)</strong><br>Ph.D. Student, Graduate School of Culture Technology<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing Lab (MACLab)</a></em><br>Advisor: Prof. Juhan Nam</li>
+          <li><strong>Sogang University</strong><br>M.A. in Art and Technology<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>Advisor: Prof. Dasaem Jeong<br>GPA: 4.15 / 4.3</li>
+          <li><strong>Seoul National University</strong><br>B.A. in Traditional Korean Music (Graduated with Highest Honors)<br>GPA: 4.08 / 4.3</li>
+          <li>Completed Teacher Certification Program in Music Education, College of Education, Seoul National University</li>
+          <li><strong>National Gugak High School</strong><br>Graduated with Highest Honors, Outstanding Major Award</li>
+          <li><strong>National Gugak Middle School</strong><br>Graduated with Highest Honors, Outstanding Major Award</li>
         </ul>
       </section>
       <section id="research">

--- a/index_ko.html
+++ b/index_ko.html
@@ -85,31 +85,12 @@
       <section id="education">
         <h2>학력</h2>
         <ul>
-          <li>
-            
-            <strong>한국과학기술원(KAIST)</strong> (2024.03~)<br>
-            문화기술대학원 박사과정<br>
-            Music and Audio Computing (MAC) Lab | 지도교수: 남주한
-          </li>
-          <li>
-            
-            <strong>서강대학교</strong> (2022.03~2024.02)<br>
-            예술과학 석사 (아트앤테크놀로지학과)<br>
-            Music and Art Learning (MALer) Lab | 지도교수: 정다샘<br>
-            GPA: 4.15 / 4.3
-          </li>
-          <li>
-            
-            <strong>서울대학교</strong> (2017.03~2021.08)<br>
-            음악대학 국악과 학사 (최우등 졸업)<br>
-            사범대학 음악교육 교직 이수<br>
-            GPA: 4.08 / 4.3
-          </li>
-          <li>
-            
-            <strong>국립국악중·고등학교</strong> (2011.03~2017.02)<br>
-            수석 졸업, 전공 최우수상
-          </li>
+          <li><strong>한국과학기술원(KAIST) 문화기술대학원</strong><br>박사과정 재학<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing (MAC) Lab</a></em><br>지도교수: 남주한</li>
+          <li><strong>서강대학교 아트앤테크놀로지학과</strong><br>예술과학 석사 졸업<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>지도교수: 정다샘<br>GPA: 4.15 / 4.3</li>
+          <li><strong>서울대학교 음악대학 국악과</strong><br>학사(수석졸업, 최우등졸업)<br>GPA: 4.08 / 4.3</li>
+          <li>서울대학교 사범대학 음악교육과 교직 이수</li>
+          <li><strong>국립국악고등학교</strong><br>졸업(학교장상, 문화체육부장관상, 전공우수상)</li>
+          <li><strong>국립국악학교</strong><br>졸업(학교장상, 국립국악원장상, 전공우수상)</li>
         </ul>
       </section>
 


### PR DESCRIPTION
## Summary
- Expand English homepage education section with detailed degree history and lab links.
- Mirror detailed education content on Korean homepage.
- Replace education page list with bilingual entries including advisors, GPAs, and honors.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b4027220832e959ba2c57a0134cb