### PR TITLE
Improve education section layout and styling

### DIFF
--- a/education.html
+++ b/education.html
@@ -31,28 +31,28 @@
       <h1><span class="lang-en">Education</span><span class="lang-ko">학력</span></h1>
       <ul>
         <li>
-          <span class="lang-en"><strong>Korea Advanced Institute of Science and Technology (KAIST)</strong> – Ph.D. Student, Graduate School of Culture Technology<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing Lab (MACLab)</a></em><br>Advisor: Prof. Juhan Nam</span>
-          <span class="lang-ko"><strong>한국과학기술원(KAIST) 문화기술대학원</strong> – 박사과정 재학<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing (MAC) Lab</a></em><br>지도교수: 남주한</span>
+          <span class="lang-en"><strong>Korea Advanced Institute of Science and Technology (KAIST)</strong><br><span class="edu-detail">Ph.D. Student, Graduate School of Culture Technology – <em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing Lab (MACLab)</a></em> | Advisor: Prof. Juhan Nam</span></span>
+          <span class="lang-ko"><strong>한국과학기술원(KAIST) 문화기술대학원</strong><br><span class="edu-detail">박사과정 재학 – <em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing (MAC) Lab</a></em> | 지도교수: 남주한</span></span>
         </li>
         <li>
-          <span class="lang-en"><strong>Sogang University</strong> – M.A. in Art and Technology<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>Advisor: Prof. Dasaem Jeong<br>GPA: 4.15 / 4.3</span>
-          <span class="lang-ko"><strong>서강대학교 아트앤테크놀로지학과</strong> – 예술과학 석사<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>지도교수: 정다샘<br>GPA: 4.15 / 4.3</span>
+          <span class="lang-en"><strong>Sogang University</strong><br><span class="edu-detail">M.A. in Art and Technology – <em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em> | Advisor: Prof. Dasaem Jeong | GPA: 4.15 / 4.3</span></span>
+          <span class="lang-ko"><strong>서강대학교 아트앤테크놀로지학과</strong><br><span class="edu-detail">예술과학 석사 – <em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em> | 지도교수: 정다샘 | GPA: 4.15 / 4.3</span></span>
         </li>
         <li>
-          <span class="lang-en"><strong>Seoul National University</strong> – B.A. in Traditional Korean Music (Graduated with Highest Honors)<br>GPA: 4.08 / 4.3</span>
-          <span class="lang-ko"><strong>서울대학교 음악대학 국악과</strong> – 학사(수석졸업, 최우등졸업)<br>GPA: 4.08 / 4.3</span>
+          <span class="lang-en"><strong>Seoul National University</strong><br><span class="edu-detail">B.M. in Traditional Korean Music (Highest Honors) | GPA: 4.08 / 4.3</span></span>
+          <span class="lang-ko"><strong>서울대학교 음악대학 국악과</strong><br><span class="edu-detail">음악학사(수석, 최우등) | GPA: 4.08 / 4.3</span></span>
         </li>
         <li>
-          <span class="lang-en">Completed Teacher Certification Program in Music Education, College of Education, Seoul National University</span>
-          <span class="lang-ko">서울대학교 사범대학 음악교육과 교직 이수</span>
+          <span class="lang-en"><span class="edu-detail">Completed Teacher Certification Program in Music Education, College of Education, Seoul National University</span></span>
+          <span class="lang-ko"><span class="edu-detail">서울대학교 사범대학 음악교육과 교직 이수</span></span>
         </li>
         <li>
-          <span class="lang-en"><strong>National Gugak High School</strong> – Graduated with Highest Honors, Outstanding Major Award</span>
-          <span class="lang-ko"><strong>국립국악고등학교</strong> – 졸업(학교장상, 문화체육부장관상, 전공우수상)</span>
+          <span class="lang-en"><strong>National Gugak High School</strong><br><span class="edu-detail">Highest Honors, Outstanding Major Award</span></span>
+          <span class="lang-ko"><strong>국립국악고등학교</strong><br><span class="edu-detail">학교장상, 문화체육부장관상, 전공우수상</span></span>
         </li>
         <li>
-          <span class="lang-en"><strong>National Gugak School</strong> – Graduated with Highest Honors, Outstanding Major Award</span>
-          <span class="lang-ko"><strong>국립국악학교</strong> – 졸업(학교장상, 국립국악원장상, 전공우수상)</span>
+          <span class="lang-en"><strong>National Gugak School</strong><br><span class="edu-detail">Highest Honors, Outstanding Major Award</span></span>
+          <span class="lang-ko"><strong>국립국악학교</strong><br><span class="edu-detail">학교장상, 국립국악원장상, 전공우수상</span></span>
         </li>
       </ul>
       </main>

--- a/index.html
+++ b/index.html
@@ -64,12 +64,12 @@
       <section id="education">
         <h2>Education</h2>
         <ul>
-          <li><strong>Korea Advanced Institute of Science and Technology (KAIST)</strong><br>Ph.D. Student, Graduate School of Culture Technology<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing Lab (MACLab)</a></em><br>Advisor: Prof. Juhan Nam</li>
-          <li><strong>Sogang University</strong><br>M.A. in Art and Technology<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>Advisor: Prof. Dasaem Jeong<br>GPA: 4.15 / 4.3</li>
-          <li><strong>Seoul National University</strong><br>B.A. in Traditional Korean Music (Graduated with Highest Honors)<br>GPA: 4.08 / 4.3</li>
-          <li>Completed Teacher Certification Program in Music Education, College of Education, Seoul National University</li>
-          <li><strong>National Gugak High School</strong><br>Graduated with Highest Honors, Outstanding Major Award</li>
-          <li><strong>National Gugak Middle School</strong><br>Graduated with Highest Honors, Outstanding Major Award</li>
+          <li><strong>Korea Advanced Institute of Science and Technology (KAIST)</strong><br><span class="edu-detail">Ph.D. Student, Graduate School of Culture Technology – <em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing Lab (MACLab)</a></em> | Advisor: Prof. Juhan Nam</span></li>
+          <li><strong>Sogang University</strong><br><span class="edu-detail">M.A. in Art and Technology – <em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em> | Advisor: Prof. Dasaem Jeong | GPA: 4.15 / 4.3</span></li>
+          <li><strong>Seoul National University</strong><br><span class="edu-detail">B.M. in Traditional Korean Music (Highest Honors) | GPA: 4.08 / 4.3</span></li>
+          <li><span class="edu-detail">Completed Teacher Certification Program in Music Education, College of Education, Seoul National University</span></li>
+          <li><strong>National Gugak High School</strong><br><span class="edu-detail">Highest Honors, Outstanding Major Award</span></li>
+          <li><strong>National Gugak School</strong><br><span class="edu-detail">Highest Honors, Outstanding Major Award</span></li>
         </ul>
       </section>
       <section id="research">

--- a/index_ko.html
+++ b/index_ko.html
@@ -85,12 +85,12 @@
       <section id="education">
         <h2>학력</h2>
         <ul>
-          <li><strong>한국과학기술원(KAIST) 문화기술대학원</strong><br>박사과정 재학<br><em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing (MAC) Lab</a></em><br>지도교수: 남주한</li>
-          <li><strong>서강대학교 아트앤테크놀로지학과</strong><br>예술과학 석사 졸업<br><em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em><br>지도교수: 정다샘<br>GPA: 4.15 / 4.3</li>
-          <li><strong>서울대학교 음악대학 국악과</strong><br>학사(수석졸업, 최우등졸업)<br>GPA: 4.08 / 4.3</li>
-          <li>서울대학교 사범대학 음악교육과 교직 이수</li>
-          <li><strong>국립국악고등학교</strong><br>졸업(학교장상, 문화체육부장관상, 전공우수상)</li>
-          <li><strong>국립국악학교</strong><br>졸업(학교장상, 국립국악원장상, 전공우수상)</li>
+          <li><strong>한국과학기술원(KAIST) 문화기술대학원</strong><br><span class="edu-detail">박사과정 재학 – <em><a href="https://mac.kaist.ac.kr/people.html" target="_blank">Music and Audio Computing (MAC) Lab</a></em> | 지도교수: 남주한</span></li>
+          <li><strong>서강대학교 아트앤테크놀로지학과</strong><br><span class="edu-detail">예술과학 석사 – <em><a href="https://malerlab.github.io/" target="_blank">Music and Art Learning (MALer) Lab</a></em> | 지도교수: 정다샘 | GPA: 4.15 / 4.3</span></li>
+          <li><strong>서울대학교 음악대학 국악과</strong><br><span class="edu-detail">음악학사(수석, 최우등) | GPA: 4.08 / 4.3</span></li>
+          <li><span class="edu-detail">서울대학교 사범대학 음악교육과 교직 이수</span></li>
+          <li><strong>국립국악고등학교</strong><br><span class="edu-detail">학교장상, 문화체육부장관상, 전공우수상</span></li>
+          <li><strong>국립국악학교</strong><br><span class="edu-detail">학교장상, 국립국악원장상, 전공우수상</span></li>
         </ul>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -186,6 +186,21 @@ p {
   margin: 1.8em 0;
 }
 
+/* education details */
+.edu-detail {
+  font-size: 0.95rem;
+  color: #666;
+}
+
+.edu-detail a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.edu-detail a:hover {
+  text-decoration: underline;
+}
+
 /* research entries */
 .paper-entry {
   margin-bottom: 24px;


### PR DESCRIPTION
## Summary
- Style education links to inherit text color and shrink details for clearer hierarchy
- Consolidate lab and advisor details into single lines for each institution
- Update degree to B.M. and remove redundant graduation wording

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b69ad8cc832e8bd38e159ad99c08