### PR TITLE
style: display white background outside content area

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: "NanumSquare", sans-serif;
-  background: #F3E9DC;
+  background: #fff;
   margin: 0;
   color: #444;
   line-height: 1.6;
@@ -125,6 +125,7 @@ body.lang-ko .lang-en {
   margin-left: 200px;
   padding: 60px 40px 40px;
   max-width: 900px;
+  background: #F3E9DC;
 }
 
 .content section + section {


### PR DESCRIPTION
## Summary
- Set global background to white so extra screen space is plain
- Apply previous beige background specifically to content area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b715b4d4832e97d04bb4043162fa