### PR TITLE
Add year toggle for news section

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,14 +51,32 @@
         <img src="images/figure.png" alt="Cover image" class="cover-image">
       </section>
       <section id="news">
-        <h2>🤗 News</h2>
-        <ul>
+        <div class="news-header">
+          <h2>🤗 News</h2>
+          <div class="year-toggle">
+            <button class="year-btn active" data-year="2025">2025</button>
+            <button class="year-btn" data-year="2024">2024</button>
+          </div>
+        </div>
+        <ul id="news-2025">
           <li><strong>2025.10.17:</strong> Session presentation scheduled at the Conference of the Society of the Korean Folk Song</li>
           <li><strong>2025.06.05:</strong> Guest Appearance on a Special Radio Program for Gugak Day, Gugak FM <a href="https://www.igbf.kr/gugak_web/?sub_num=760&state=view&idx=265797">Link</a> <a href="https://igbf.kr/gugak_web/?sub_num=764&state=view&idx=265509">Link2</a></li>
           <li><strong>2025.05.31:</strong> Session presentation at the 50th Anniversary Conference of the Society of Korean Music Educators</li>
           <li><strong>2025.04.18:</strong> Poster presentation at the Korean Society of Music Informatics (KSMI)</li>
           <li><strong>2025.03.13:</strong> Invited talk at MUSAIC, UC San Diego (Remote)</li>
           <li><strong>2025.01:</strong> "On the automatic recognition of Jeongganbo music notation: dataset and approach" accepted to <em>ACM Journal on Computing and Cultural Heritage (JOCCH)</em></li>
+        </ul>
+        <ul id="news-2024" class="hidden">
+          <li><strong>2024.10.15:</strong> My ISMIR paper got nominated for <strong>Best Paper Award!</strong> 🏆</li>
+          <li><strong>2024.10.12:</strong> 🎉🎉🎉 "Towards Computational Analysis of Pansori Singing” has been accepted to the Late Breaking Demo (LBD) session at ISMIR 2024. <a href="https://ismir2024program.ismir.net/lbd_503.html">Link</a></li>
+          <li><strong>2024.07.22:</strong> "On the Automatic Recognition of Jeongganbo Music Notation: Dataset and Approach" has been released as a preprint. <a href="https://www.researchsquare.com/article/rs-4668854/v1">Link</a></li>
+          <li><strong>2024.06.21:</strong> 🎉🎉🎉 "Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding” was accepted to <a href="https://ismir2024.ismir.net/">ISMIR 2024</a> <a href="https://sogang.ac.kr/ko/detail/545309">Link</a></li>
+          <li><strong>2024.06.02:</strong> <em>Chiwhapyeong</em> and <em>Chwipungnyeong</em> restored by AI were showcased at the National Gugak Center on June 2, 2024. <a href="https://www.donga.com/news/Culture/article/all/20240609/125342346/1">Link1</a> <a href="https://www.koya-culture.com/mobile/article.html?no=145751">Link2</a></li>
+          <li><strong>2024.05.14:</strong> King Sejong's music <em>Chihwapyeong</em> and <em>Chwipunghyeong</em> were reconstructed and performed in a Sejong’s birthday commemorative event at Gyeongbokgung <a href="https://www.donga.com/news/Culture/article/all/20240513/124920100/1">Link1</a> <a href="https://creative.sogang.ac.kr/%EC%95%84%ED%8A%B8amp%ED%85%8C%ED%81%AC%EB%86%80%EB%A1%9C%EC%A7%80%ED%95%99%EA%B3%BC-%EC%A0%95%EB%8B%A4%EC%83%98-%EA%B5%90%EC%88%98-%EC%97%B0%EA%B5%AC%ED%8C%80_%EC%84%B8%EC%A2%85%EB%8C%80%EC%99%95/">Link2</a> <a href="https://www.segye.com/newsView/20240513504438?OutUrl=naver">Link3</a></li>
+          <li><strong>2024.03.01:</strong> I gave a presentation at the <a href="https://www.aesthetics.mpg.de/forschung/forschungsgruppe-computational-auditory-perception.html">"Computational Auditory Perception"</a> group at the <a href="https://www.aesthetics.mpg.de/">Max Planck Institute for Empirical Aesthetics</a> in Frankfurt.</li>
+          <li><strong>2024.02.26:</strong> I started my PhD program at the <a href="https://ct.kaist.ac.kr/">Graduate School of Culture Technology</a> at KAIST.</li>
+          <li><strong>2024.01.22:</strong> I received an award for <strong>outstanding paper</strong> at the '2023 Sogang University Graduate School Excellent Thesis Competition’. <a href="https://www.sogang.ac.kr/front/boardview.do?pkid=541197&currentPage=1&searchField=ALL&siteGubun=1&menuGubun=1&bbsConfigFK=143&searchLowItem=ALL&searchValue=">Link1</a> <a href="http://creative.sogang.ac.kr/%EC%84%9D%EC%82%AC%EA%B3%BC%EC%A0%95-%ED%95%9C%EB%8B%A8%EB%B9%84%EB%82%B4%EB%A6%B0-%EB%B3%B8%EA%B5%90-%EC%A0%9C2%ED%9A%8C-%EB%8C%80%ED%95%99%EC%9B%90%EC%83%9D-%EC%9A%B0%EC%88%98%EB%85%BC%EB%AC%B8/">Link2</a></li>
+          <li><strong>2024.01.07:</strong> 🎉🎉🎉 I received approval from the review professors for my master's thesis and submitted it. It's my master's graduation!!!</li>
         </ul>
       </section>
       <section id="education">

--- a/index_ko.html
+++ b/index_ko.html
@@ -53,8 +53,14 @@
       </section>
 
       <section id="news">
-        <h2>🤗 소식</h2>
-        <ul>
+        <div class="news-header">
+          <h2>🤗 소식</h2>
+          <div class="year-toggle">
+            <button class="year-btn active" data-year="2025">2025</button>
+            <button class="year-btn" data-year="2024">2024</button>
+          </div>
+        </div>
+        <ul id="news-2025">
           <li>
 
             <strong>2025.10.17:</strong> 한국민요학회 학술대회 세션 발표 예정
@@ -79,6 +85,18 @@
 
             <strong>2025.01:</strong> "정간보 음악 기보의 자동 인식을 위한 데이터셋과 접근법" 논문이 <em>ACM Journal on Computing and Cultural Heritage (JOCCH)</em>에 게재 승인되었습니다.
           </li>
+        </ul>
+        <ul id="news-2024" class="hidden">
+          <li><strong>2024.10.15:</strong> ISMIR 논문이 <strong>최우수 논문상</strong> 후보에 올랐습니다! 🏆</li>
+          <li><strong>2024.10.12:</strong> 🎉🎉🎉 "Towards Computational Analysis of Pansori Singing"이 ISMIR 2024 LBD 세션에 채택되었습니다. <a href="https://ismir2024program.ismir.net/lbd_503.html">링크</a></li>
+          <li><strong>2024.07.22:</strong> "정간보 음악 기보의 자동 인식을 위한 데이터셋과 접근법"이 사전 공개(preprint)되었습니다. <a href="https://www.researchsquare.com/article/rs-4668854/v1">링크</a></li>
+          <li><strong>2024.06.21:</strong> 🎉🎉🎉 "Six Dragons Fly Again: Reviving 15th-Century Korean Court Music with Transformers and Novel Encoding"이 ISMIR 2024에 채택되었습니다. <a href="https://sogang.ac.kr/ko/detail/545309">링크</a></li>
+          <li><strong>2024.06.02:</strong> AI로 복원한 <em>치화평</em>과 <em>취풍령</em>이 2024년 6월 2일 국립국악원에서 공개되었습니다. <a href="https://www.donga.com/news/Culture/article/all/20240609/125342346/1">링크1</a> <a href="https://www.koya-culture.com/mobile/article.html?no=145751">링크2</a></li>
+          <li><strong>2024.05.14:</strong> 세종대왕 탄신 기념 행사에서 세종대왕의 음악 <em>치화평</em>과 <em>취풍형</em>이 복원·연주되었습니다. <a href="https://www.donga.com/news/Culture/article/all/20240513/124920100/1">링크1</a> <a href="https://creative.sogang.ac.kr/%ec%95%84%ed%8a%b8amp%ed%85%8c%ed%81%ac%eb%86%80%eb%a1%9c%ec%a7%80%ed%95%99%ea%b3%bc-%ec%a0%95%eb%8b%a4%ec%83%98-%ea%b5%90%ec%88%98-%ec%97%b0%ea%b5%ac%ed%8c%80_%ec%84%b8%ec%a2%85%eb%8c%80%ec%99%95/">링크2</a> <a href="https://www.segye.com/newsView/20240513504438?OutUrl=naver">링크3</a></li>
+          <li><strong>2024.03.01:</strong> 프랑크푸르트 막스플랑크 예술인지 연구소의 <a href="https://www.aesthetics.mpg.de/forschung/forschungsgruppe-computational-auditory-perception.html">Computational Auditory Perception</a> 그룹에서 발표했습니다.</li>
+          <li><strong>2024.02.26:</strong> KAIST 문화기술대학원 박사과정을 시작했습니다.</li>
+          <li><strong>2024.01.22:</strong> '2023 서강대학교 대학원 우수논문 공모전'에서 <strong>우수논문상</strong>을 수상했습니다. <a href="https://www.sogang.ac.kr/front/boardview.do?pkid=541197&currentPage=1&searchField=ALL&siteGubun=1&menuGubun=1&bbsConfigFK=143&searchLowItem=ALL&searchValue=">링크1</a> <a href="http://creative.sogang.ac.kr/%EC%84%9D%EC%82%AC%EA%B3%BC%EC%A0%95-%ED%95%9C%EB%8B%A8%EB%B9%84%EB%82%B4%EB%A6%B0-%EB%B3%B8%EA%B5%90-%EC%A0%9C2%ED%9A%8C-%EB%8C%80%ED%95%99%EC%9B%90%EC%83%9D-%EC%9A%B0%EC%88%98%EB%85%BC%EB%AC%B8/">링크2</a></li>
+          <li><strong>2024.01.07:</strong> 🎉🎉🎉 석사 논문 심사를 통과하고 제출했습니다. 석사 졸업!!!</li>
         </ul>
       </section>
 

--- a/script.js
+++ b/script.js
@@ -13,10 +13,10 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  const sidebarLinks = document.querySelectorAll('.sidebar a[href^="#"]');
-  const sections = Array.from(sidebarLinks)
-    .map((link) => document.querySelector(link.getAttribute("href")))
-    .filter(Boolean);
+    const sidebarLinks = document.querySelectorAll('.sidebar a[href^="#"]');
+    const sections = Array.from(sidebarLinks)
+      .map((link) => document.querySelector(link.getAttribute("href")))
+      .filter(Boolean);
 
   if (sidebarLinks.length && sections.length) {
     const activateSidebar = () => {
@@ -44,6 +44,26 @@ document.addEventListener("DOMContentLoaded", function () {
         link.classList.add("active");
       });
     });
-    activateSidebar();
-  }
-});
+      activateSidebar();
+    }
+
+    const yearButtons = document.querySelectorAll('.year-btn');
+    const news2024 = document.getElementById('news-2024');
+    const news2025 = document.getElementById('news-2025');
+
+    if (yearButtons.length && news2024 && news2025) {
+      yearButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          yearButtons.forEach((b) => b.classList.remove('active'));
+          btn.classList.add('active');
+          if (btn.dataset.year === '2024') {
+            news2024.classList.remove('hidden');
+            news2025.classList.add('hidden');
+          } else {
+            news2025.classList.remove('hidden');
+            news2024.classList.add('hidden');
+          }
+        });
+      });
+    }
+  });

--- a/style.css
+++ b/style.css
@@ -179,6 +179,38 @@ h2 {
   font-size: 0.95rem;
 }
 
+#news a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.news-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.year-toggle button {
+  margin-left: 8px;
+  padding: 4px 8px;
+  border: 1px solid #D96F32;
+  background: #F3E9DC;
+  color: #D96F32;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.year-toggle button.active,
+.year-toggle button:hover {
+  background: #D96F32;
+  color: #F3E9DC;
+}
+
+.hidden {
+  display: none;
+}
+
 ul {
   padding-left: 20px;
 }


### PR DESCRIPTION
## Summary
- add year toggle to news section with 2024 and 2025 options
- include 2024 news entries in English and Korean, with neutral link styling
- implement JavaScript and CSS to switch news by selected year

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7d2b76c832eb7c13dfebed5f897