### PR TITLE
feat: split intro paragraphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,10 @@
             <span class="keyword">computational musicology</span>
             <span class="keyword">music AI</span>
           </div>
-          <p>I am a Ph.D. student at the Music and Audio Computing Lab (MACLab), advised by Professors Juhan Nam and Dasaem Jeong.
-            My research applies Music Information Retrieval (MIR) and music AI to Gugak (Korean traditional music), focusing on its unique idioms and expressive characteristics that are often overlooked in conventional analysis.
-            With over 15 years of experience as a haegeum performer, I combine performance-based musical intuition with data-driven analytical methods to investigate what constitutes the "Korean-ness" in our music. My work aims to illuminate the musical significance of these expressive features and to articulate the value of Korean traditional music within the broader context of contemporary global music.</p>
+          <p><strong>I am a Ph.D. student</strong> at the <strong>Music and Audio Computing Lab (MACLab)</strong>, advised by Professors Juhan Nam and Dasaem Jeong.</p>
+          <p>My research applies <strong>Music Information Retrieval (MIR)</strong> and <strong>music AI</strong> to <strong>Gugak (Korean traditional music)</strong>, focusing on its unique idioms and expressive characteristics that are often overlooked in conventional analysis.</p>
+          <p>With over <strong>15 years</strong> of experience as a <strong>haegeum performer</strong>, I combine performance-based musical intuition with data-driven analytical methods to investigate what constitutes the "Korean-ness" in our music.</p>
+          <p>My work aims to illuminate the musical significance of these expressive features and to articulate the value of <strong>Korean traditional music</strong> within the broader context of contemporary global music.</p>
           <p><strong>E-mail:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
           <div class="social-icons">
             <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="CV" target="_blank"><i class="fa-solid fa-file"></i></a>

--- a/index_ko.html
+++ b/index_ko.html
@@ -39,12 +39,12 @@
               <span class="keyword">전산음악학</span>
               <span class="keyword">음악 인공지능</span>
             </div>
-            <p><strong>안녕하세요, 한단비내린입니다</strong></p>
-            <p>현재 카이스트 Music and Audio Computing Lab(MACLab)에서 남주한, 정다샘 교수님의 지도를 받으며 음악 인공지능을 이용한 국악 연구로 박사과정을 밟고 있습니다. </p>
-            <p></p>오랜동안 해금을 연주해 온 연주자로서, 또 전통음악을 보고 접해 온 학생으로서, 늘 궁금증이 있었습니다. 나는 '한국음악다움'에 대해 얼마나 알고 있는가입니다. 다른 음악과 구별되는 우리 음악의 특징은 어떻게 정의되고 계산되어질 수 있을까요.
-            저는 음악정보처리(MIR) 기술을 통해 기존의 분석 방식으로는 미처 포착하지 못했던 국악의 고유한 어법과 유연한 표현력을 새롭게 조명하고 그 안에 담긴 음악적 의미를 탐구하고자 합니다.
-          </p><p>연주자로서 체득한 음악적 직관과 연구자로서 갖춘 실증적 분석 역량을 결합하여, 동시대 글로벌 음악 속에서 한국 음악의 가치를 새롭게 연결하고 설명하는 연구자가 되고자 합니다.</p>
-            <p><strong>이메일:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
+              <p><strong>안녕하세요, 한단비내린입니다</strong></p>
+              <p>현재 <strong>카이스트 Music and Audio Computing Lab (MACLab)</strong>에서 <strong>남주한</strong>, <strong>정다샘</strong> 교수님의 지도를 받으며 <strong>음악 인공지능</strong>을 이용한 <strong>국악 연구</strong>로 박사과정을 밟고 있습니다.</p>
+              <p><strong>오랜동안 해금을 연주해 온 연주자</strong>이자 전통음악을 접해 온 학생으로서, 늘 궁금했습니다. 나는 '<strong>한국음악다움</strong>'을 얼마나 알고 있는가? 다른 음악과 구별되는 우리 음악의 특징은 어떻게 정의되고 계산될 수 있을까요.</p>
+              <p>저는 <strong>음악정보처리(MIR)</strong> 기술을 통해 기존의 분석 방식으로는 미처 포착하지 못했던 <strong>국악의 고유한 어법과 유연한 표현력</strong>을 새롭게 조명하고 그 안에 담긴 음악적 의미를 탐구하고자 합니다.</p>
+              <p>연주자로서 체득한 음악적 직관과 연구자로서 갖춘 실증적 분석 역량을 결합하여, 동시대 글로벌 음악 속에서 <strong>한국 음악의 가치</strong>를 새롭게 연결하고 설명하는 연구자가 되고자 합니다.</p>
+              <p><strong>이메일:</strong> naerin71@kaist.ac.kr | danbinaerin@naver.com</p>
               <div class="social-icons">
                 <a href="https://docs.google.com/document/d/1JQlFtoFbnxZKOq2Lw0hG3NLOCV1yea_OUEyrioB7Irc/edit?usp=sharing" class="icon" title="이력서" target="_blank"><i class="fa-solid fa-file"></i></a>
                 <a href="https://github.com/danbinaerinHan" class="icon" title="깃허브" target="_blank"><i class="fab fa-github"></i></a>


### PR DESCRIPTION
## Summary
- Break long intro on English landing page into clear paragraphs with bolded keywords
- Reorganize Korean intro section with multiple paragraphs and emphasized terms

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a69e8bd440832eb6c209b45bafdfeb